### PR TITLE
feat(skill): add configurable skill destinations and bootstrap config

### DIFF
--- a/skill/README.md
+++ b/skill/README.md
@@ -10,37 +10,147 @@ skill/
   src/
     cli.rb
     skill/
+      config.rb
       doctor.rb
       error.rb
       filesystem.rb
       operations.rb
       paths.rb
+      state.rb
       ui.rb
+  config/
+    default-config.yml
   test/
     cli_test.rb
     unit_test.rb
 ```
 
 - `src/cli.rb`: command parsing, dispatch, and help output
+- `src/skill/config.rb`: central and project-local config loading and normalization
 - `src/skill/paths.rb`: canonical store and project path resolution
+- `src/skill/state.rb`: shared destination state inspection used by status, doctor, and mutating commands
 - `src/skill/filesystem.rb`: shared symlink and skill-name safety helpers
 - `src/skill/error.rb`: shared CLI exit/error object used below the entrypoint
 - `src/skill/operations.rb`: skill list/status/link/unlink/clean/adopt/promote/rename behavior
 - `src/skill/doctor.rb`: doctor scan and reporting behavior
 - `src/skill/ui.rb`: CLI output and fatal error helpers
+- `config/default-config.yml`: documented template for `~/.config/skill/config.yml`
 - `test/cli_test.rb`: characterization tests for command parsing and filesystem behavior
 - `test/unit_test.rb`: direct object tests for operation and doctor edge cases
 - `../scripts/skill`: thin executable entrypoint
+
+## Configuration
+
+The CLI reads configuration from:
+
+- central config: `~/.config/skill/config.yml`
+- project-local config: `<project>/.skill.yml`
+
+Config precedence is:
+
+1. built-in defaults
+2. central config
+3. project-local config
+
+The central config defines known tool profiles and their preferred skill destinations.
+The project config selects active tools for a specific repository and can add extra destinations.
+
+### Default behavior
+
+Out of the box, the CLI behaves exactly like the original version:
+
+- canonical store: `skills/` at the dotfiles root
+- active tool set: `codex`
+- authoring destination: `.codex/skills`
+
+### Authoring vs mirror destinations
+
+Exactly one destination is the authoring destination for a project.
+That is where a local skill is expected to be created before `skill promote <name>`.
+Any other configured destinations are mirrors that receive symlinks to the canonical store.
+
+### Central config example
+
+Copy `skill/config/default-config.yml` to `~/.config/skill/config.yml` and adjust as needed.
+
+Example:
+
+```yaml
+store_dir: skills
+
+tools:
+  codex:
+    destinations:
+      - .codex/skills
+    authoring: true
+
+  generic:
+    destinations:
+      - .skills
+
+  github:
+    destinations:
+      - .github/skills
+
+defaults:
+  tools:
+    - codex
+  authoring_tool: codex
+```
+
+### Project config example
+
+```yaml
+tools:
+  - codex
+  - github
+
+extra_destinations:
+  - .skills
+```
+
+### Promotion workflow
+
+Recommended workflow:
+
+1. Create a skill in the authoring destination.
+2. Run `skill promote <name>`.
+3. The CLI moves the directory into the canonical store.
+4. The CLI links the stored version back into all configured destinations.
+
+If the authoring destination is missing but exactly one mirror destination contains the local skill directory, `promote` uses that mirror as a fallback and emits a note.
+If multiple destinations contain local directories with the same skill name, `promote` fails closed.
+
+### First-run setup
+
+Initialize the central config with:
+
+```sh
+skill config init
+```
+
+That writes `~/.config/skill/config.yml` from `skill/config/default-config.yml` and refuses to overwrite an existing config.
+
+The usual first checks after setup are:
+
+```sh
+skill status
+skill doctor
+```
+
+### Symlink behavior
+
+Linked skills use relative symlinks where possible so project links remain portable when inspected or moved with the project directory structure intact.
 
 ## Useful Commands
 
 Run the CLI entrypoint:
 
 ```sh
-./scripts/skill help
-./scripts/skill list
-./scripts/skill status
-./scripts/skill doctor
+skill help
+skill list
+skill status
+skill doctor
 ```
 
 Run the implementation directly:
@@ -97,3 +207,4 @@ Run tests with the macOS system Ruby 2.6:
 - When changing command behavior, update or add tests in `skill/test/cli_test.rb` first when practical.
 - Preserve Ruby 2.6 compatibility.
 - Prefer stdlib-only dependencies unless there is a strong reason not to.
+- Keep config and destination policy understandable from CLI output and README examples.

--- a/skill/config/default-config.yml
+++ b/skill/config/default-config.yml
@@ -1,0 +1,39 @@
+# Central skill CLI configuration.
+#
+# This file defines known tool profiles and their preferred project-local
+# skill destinations. The dotfiles skill store remains the canonical source
+# of truth; project paths are linked working sets.
+#
+# Copy this file to:
+#   ~/.config/skill/config.yml
+#
+# By default only the `codex` tool is active. Projects can opt into additional
+# tools with <project>/.skill.yml.
+
+# Relative paths are resolved from the dotfiles root.
+store_dir: skills
+
+tools:
+  codex:
+    # Codex-compatible working set.
+    destinations:
+      - .codex/skills
+    # Exactly one active tool should resolve as the authoring destination.
+    authoring: true
+
+  generic:
+    # Generic tool compatibility path.
+    destinations:
+      - .skills
+
+  github:
+    # GitHub-specific skill path for tools that inspect repository metadata.
+    destinations:
+      - .github/skills
+
+defaults:
+  # Default active tool set for projects without local overrides.
+  tools:
+    - codex
+  # Optional. If omitted, the first active authoring-capable tool is used.
+  authoring_tool: codex

--- a/skill/delivery-plan.md
+++ b/skill/delivery-plan.md
@@ -1,0 +1,648 @@
+# Skill CLI Delivery Plan
+
+## Goal
+
+Evolve the `skill` CLI from a single hardcoded project destination (`.codex/skills`) into a small, dependable utility that:
+
+- keeps the dotfiles `skills/` directory as the canonical store
+- supports configurable project-local skill destinations
+- supports multiple linked destinations to cover tool mismatch
+- introduces a centralized config for known AI agent/tool preferences
+- preserves safe filesystem behavior and Ruby 2.6 compatibility
+
+This plan is intentionally implementation-oriented and avoids unnecessary abstraction.
+
+## Current Intent
+
+The intended workflow is:
+
+1. A user or agent creates a skill locally in a project.
+2. The CLI promotes that skill into the central store.
+3. The CLI links the stored version back into one or more project-local destinations.
+4. Different tools can find skills where they expect them.
+
+Canonical store remains:
+
+- `~/.dotfiles/skills`
+
+Project destinations should become configurable instead of hardcoded to:
+
+- `.codex/skills`
+
+Examples of additional destinations to support:
+
+- `.skills`
+- `.github/skills`
+
+## Constraints
+
+- Ruby must remain compatible with macOS system Ruby 2.6.
+- Prefer stdlib only.
+- `scripts/skill` must remain a thin launcher.
+- Hidden store directories remain excluded from listing and bulk linking.
+- The CLI should fail closed on ambiguous or unsafe filesystem states.
+- CLI behavior should stay understandable from output alone.
+- Prefer direct Ruby code over indirection-heavy design.
+
+## Review Summary Of Current Draft
+
+The current draft moves in the right direction, but it is incomplete and not yet a stable architecture.
+
+### What is good
+
+- Introduces configurable destinations instead of hardcoding only `.codex/skills`.
+- Starts moving path resolution through config.
+- Starts scanning multiple destinations in `status`, `doctor`, `clean`, `link`, and `promote`.
+
+### Main gaps
+
+1. Config is project-local only.
+   It loads `.skill.yml` from the project root, but there is no central registry of known tool preferences.
+
+2. There is no authoritative authoring destination.
+   `promote` scans all configured destinations and picks the first local directory it finds, which is ambiguous.
+
+3. Name mapping is only partially wired.
+   `doctor` knows about mapping, but mutating operations still assume store name == project link name.
+
+4. Multi-destination failure behavior is not fully defined.
+   Some operations now log-and-continue instead of failing closed.
+
+5. Tests and README were not updated with the new contract.
+
+## Target Architecture
+
+Keep the architecture small and direct. Use a few focused Ruby files with concrete responsibilities.
+
+### Proposed files
+
+- `src/skill/config.rb`
+  Loads and merges built-in defaults, central config, and project-local overrides.
+
+- `src/skill/layout.rb`
+  Resolves active tool profiles into concrete destination paths for the current project.
+
+- `src/skill/state.rb`
+  Inspects filesystem state for a skill across configured destinations.
+
+- `src/skill/paths.rb`
+  Keeps simple path helpers and project/store root detection.
+
+- `src/skill/operations.rb`
+  Performs filesystem mutations using resolved layout/state results.
+
+- `src/skill/doctor.rb`
+  Reports health using the same state classification logic.
+
+This is still a direct Ruby design. It avoids service-object sprawl and keeps policy from leaking into every command.
+
+## Configuration Model
+
+Use a two-layer model.
+
+### 1. Central config
+
+Lives in dotfiles and defines known tool preferences.
+
+Responsibilities:
+
+- canonical store location
+- known tool profiles
+- destination preferences per tool
+- default tool selection
+- optional authoring tool default
+- optional ignore / required defaults
+
+Example shape:
+
+```yaml
+store_dir: skills
+
+tools:
+  codex:
+    destinations:
+      - .codex/skills
+    authoring: true
+
+  generic:
+    destinations:
+      - .skills
+
+  github:
+    destinations:
+      - .github/skills
+
+defaults:
+  tools:
+    - codex
+```
+
+### 2. Project-local config
+
+Lives in the project root as `.skill.yml`.
+
+Responsibilities:
+
+- select active tools for this project
+- add extra destinations if needed
+- override authoring tool
+- define ignore / required skill names
+
+Example shape:
+
+```yaml
+tools:
+  - codex
+  - github
+
+authoring_tool: codex
+
+extra_destinations:
+  - .skills
+
+ignore:
+  - secret-skill
+
+required:
+  - ruby-expert
+```
+
+### Notes
+
+- Defer `name_mappings` unless a real tool requires it.
+  It adds complexity across every mutating command.
+- Keep keys and values simple and explicit.
+- Normalize all config data once after load.
+
+## Resolved Layout
+
+Add one resolved layout step per CLI invocation.
+
+The resolved layout should answer:
+
+- what is the canonical store directory
+- which tool profiles are active
+- which project destination is the authoring destination
+- which destinations are mirrors
+- which destinations are all active destinations
+- which skills are ignored
+- which skills are required
+
+Example normalized result:
+
+```ruby
+{
+  "store_dir" => "/Users/gil/.dotfiles/skills",
+  "authoring_destination" => "/repo/.codex/skills",
+  "mirror_destinations" => [
+    "/repo/.skills",
+    "/repo/.github/skills"
+  ],
+  "all_destinations" => [
+    "/repo/.codex/skills",
+    "/repo/.skills",
+    "/repo/.github/skills"
+  ],
+  "required_skills" => ["ruby-expert"],
+  "ignored_skills" => ["secret-skill"]
+}
+```
+
+This should be plain Ruby data, not a deep object graph.
+
+## Destination State Classification
+
+Add one shared state scan helper used by `promote`, `link`, `unlink`, `status`, `clean`, `rename`, and `doctor`.
+
+For each destination and skill name, classify the path as one of:
+
+- `:missing`
+- `:local_directory`
+- `:symlink_to_store`
+- `:symlink_elsewhere`
+- `:broken_symlink`
+- `:foreign_file`
+
+Example result:
+
+```ruby
+[
+  { path: "/repo/.codex/skills/my-skill", kind: :local_directory },
+  { path: "/repo/.skills/my-skill", kind: :missing },
+  { path: "/repo/.github/skills/my-skill", kind: :symlink_to_store }
+]
+```
+
+This avoids repeating path classification logic across commands and keeps behavior aligned.
+
+## Authoring Model
+
+Introduce one clear rule:
+
+- exactly one destination is the authoring destination
+- all other configured destinations are mirrors
+
+This removes ambiguity in the common workflow where an agent creates a skill locally before promotion.
+
+### Recommended workflow
+
+1. Agent creates the skill in the authoring destination.
+2. User runs `skill promote <name>`.
+3. CLI moves the directory into the central store.
+4. CLI creates symlinks in all configured destinations.
+
+### Why this matters
+
+Without an authoring destination, `promote` must guess among several locations, which is unsafe and hard to reason about.
+
+## Command Semantics
+
+### `link <name>`
+
+- Link the stored skill into all active destinations.
+- Create missing destination directories as needed.
+- Exit non-zero if any destination could not be linked.
+- Do not overwrite foreign paths or foreign symlinks.
+
+### `link --all`
+
+- Link all non-hidden, non-ignored store skills into all active destinations.
+- Report per-destination failures.
+- Exit non-zero if any requested link failed.
+
+### `unlink <name>`
+
+- Remove matching symlinks from all active destinations.
+- Refuse to remove non-symlink paths.
+- Exit non-zero if any destination is in a conflicting state.
+
+### `promote <name>`
+
+Default behavior:
+
+1. Inspect the authoring destination first.
+2. If `<authoring_destination>/<name>` is a local directory, promote it.
+3. If it is already linked to store, report already promoted.
+4. If it is missing, optionally inspect mirrors for legacy fallback behavior.
+5. If more than one destination contains a local directory, fail closed.
+6. After moving to store, link back into all active destinations.
+7. Exit non-zero if any destination could not be linked.
+
+### `rename <old> <new>`
+
+- Rename the skill in the store.
+- Update matching symlinks in all active destinations.
+- Refuse if the new project path already exists in any destination.
+- Exit non-zero if any destination conflicts.
+
+### `doctor`
+
+- Validate every active destination.
+- Report missing destination directories as warnings unless the authoring destination is required.
+- Report local directories, foreign files, broken symlinks, and symlinks outside store.
+- Report required skills not linked where expected.
+
+### `status`
+
+- Show one grouped section per destination.
+- Display linked, broken, local, and file states.
+
+## Failure Policy
+
+Prefer explicit, safe behavior.
+
+Recommended policy:
+
+- refuse to overwrite existing files or directories
+- refuse to replace symlinks that point somewhere unexpected
+- refuse ambiguous promotion cases
+- process all destinations where reasonable
+- exit non-zero if any required destination operation failed
+
+This keeps the CLI safe while still giving complete reporting for multi-destination operations.
+
+## Delivery Stages
+
+Implement in small stages.
+
+### Stage 1: Config and layout
+
+Deliverables:
+
+- central config file location and format
+- project-local config format
+- config merge logic
+- resolved layout logic
+- tests for config precedence and destination resolution
+
+Success criteria:
+
+- current hardcoded `.codex/skills` behavior still works by default
+- project can opt into multiple destinations through config
+- one authoring destination is always resolved
+
+### Stage 2: Shared destination state scanning
+
+Deliverables:
+
+- one helper for classifying destination state
+- refactor `status` and `doctor` to use it
+- tests for all destination state kinds
+
+Success criteria:
+
+- `status` and `doctor` report consistent state
+- no duplicated state-classification logic across commands
+
+### Stage 3: Mutating commands on top of resolved state
+
+Deliverables:
+
+- refactor `link`, `unlink`, `clean`, `promote`, and `rename`
+- define and enforce multi-destination failure semantics
+- make `promote` authoring-destination-first
+- tests for ambiguous promote and partial destination conflicts
+
+Success criteria:
+
+- `promote` no longer picks arbitrary local directories
+- all mutating commands behave consistently across destinations
+- CLI exits non-zero on real conflicts
+
+### Stage 4: Documentation and compatibility cleanup
+
+Deliverables:
+
+- update `README.md`
+- update CLI help text where needed
+- add usage examples for central config and multi-destination projects
+- run full quality gate
+
+Success criteria:
+
+- docs match behavior
+- `make lint test` passes
+
+## Maintainability Guidelines
+
+- Keep command logic direct.
+- Prefer small helper methods over new abstraction layers.
+- Keep YAML parsing and normalization in one place.
+- Keep destination-state inspection in one place.
+- Keep file mutation logic in `operations.rb`.
+- Avoid name remapping until it is actually needed.
+- Avoid meta-programming and clever Enumerable chains.
+- Prefer explicit loops and early returns.
+
+## Ruby 2.6 Style Guidelines
+
+- stdlib only
+- plain hashes / arrays for normalized config and state
+- explicit string-key handling for YAML data
+- simple helper methods with narrow responsibilities
+- avoid newer Ruby features not available in 2.6
+
+Prefer:
+
+- `each`
+- `each_with_object`
+- `next`
+- early return
+- direct conditional branches
+
+Avoid:
+
+- indirection-heavy service layers
+- clever DSLs
+- unnecessary `Struct` or class proliferation
+- symbol/string key mixing from YAML
+
+## Test Matrix
+
+Add or update tests for:
+
+- default config resolves to `.codex/skills`
+- central config adds known tool destinations
+- project config selects multiple active tools
+- exactly one authoring destination is resolved
+- `link` links into all active destinations
+- `link` refuses foreign paths in one destination and exits non-zero
+- `promote` succeeds from the authoring destination
+- `promote` fails when two destinations contain local directories of the same name
+- `promote` relinks all destinations after moving to store
+- `doctor` reports missing / broken / local / foreign states per destination
+- `rename` updates matching symlinks across all destinations
+- hidden store entries remain ignored
+
+## Open Decisions
+
+These decisions should be made before implementation starts:
+
+1. Where should the central config live exactly?
+   Likely under dotfiles, but choose one stable path.
+
+2. Should mirror destination failures be fatal?
+   Recommended: yes, for mutating commands.
+
+3. Should missing mirror directories be auto-created?
+   Recommended: yes, when linking or promoting.
+
+4. Do any tools actually require different skill names?
+   If not, defer name mapping.
+
+5. Should `promote` support `--from <tool|path>` in v1?
+   Recommended: no, unless a real use case already exists.
+
+## Accepted Decisions
+
+The following decisions are now fixed for implementation unless explicitly changed later.
+
+### Config locations
+
+- Central config path: `~/.config/skill/config.yml`
+- Project-local config path: `<project>/.skill.yml`
+
+### Config precedence
+
+Merge in this order:
+
+1. built-in defaults
+2. central config
+3. project-local config
+
+Project-local config may:
+
+- override selected tools
+- override the authoring tool
+- extend destinations where supported by the schema
+- set project-local `ignore` and `required`
+
+### Tool selection
+
+- Default active tool set is `codex` only.
+- Exactly one `authoring_tool` must be resolved per project.
+- If not explicitly set by the project, the resolved authoring tool should come from central config defaults.
+
+### Promote behavior
+
+- `promote` fails hard if more than one destination contains a local directory for the same skill.
+- If the authoring destination is missing but exactly one mirror destination contains the local skill directory, `promote` may use it as a compatibility fallback and must emit a warning.
+- `promote` should not guess among multiple local directories.
+
+### Mutating command failure behavior
+
+- `link`, `link --all`, `unlink`, `promote`, `rename`, and similar mutating commands should attempt all relevant destinations where practical.
+- If any destination operation fails, the command exits non-zero after reporting all results.
+- The CLI must not overwrite foreign files, directories, or unexpected symlinks.
+
+### Destination directory creation
+
+- Missing destination directories should be auto-created for `link` and `promote`.
+
+### Name mapping
+
+- Defer `name_mappings` from v1 unless a real tool requires it.
+
+### Doctor behavior
+
+- Missing mirror destinations are warnings.
+- Problems in the authoring destination are issues when they block the expected workflow.
+
+### Symlink policy
+
+- Prefer relative symlinks if implemented safely.
+- If relative symlinks materially complicate correctness, keep absolute symlinks in v1 and revisit later.
+
+### Documentation
+
+- Proper documentation is part of delivery, not follow-up work.
+- The out-of-the-box central config template must be documented with inline comments.
+- `README.md` must explain the final config model and workflow.
+
+## Final Implementation Checklist
+
+This is the concrete execution order for autonomous delivery.
+
+### 1. Add config files and schema support
+
+- Add support for reading `~/.config/skill/config.yml`
+- Keep support for `<project>/.skill.yml`
+- Normalize config after load:
+  - expand `~`
+  - resolve store path
+  - normalize tool names and destination arrays
+  - validate that one authoring tool can be resolved
+- Add a documented default central config template in the repo
+
+Suggested repository addition:
+
+- `config/default-config.yml`
+  or
+- `templates/config.yml`
+
+The template should be heavily commented and safe as the documented OOTB example.
+
+### 2. Implement resolved layout logic
+
+- Compute active tools from defaults + central config + project overrides
+- Resolve exactly one authoring destination
+- Resolve mirror destinations
+- Resolve full destination list without duplicates
+- Resolve ignored and required skill lists
+
+Keep this logic explicit and Ruby 2.6-friendly.
+
+### 3. Implement shared destination-state inspection
+
+- Add one helper that classifies each destination path for a given skill
+- Reuse it across `status`, `doctor`, `link`, `unlink`, `promote`, `clean`, and `rename`
+- Keep the returned state as plain hashes or simple Ruby objects
+
+### 4. Refactor non-mutating commands first
+
+- Update `status` to render grouped output per destination
+- Update `doctor` to use the shared state scan
+- Make `doctor` distinguish warnings vs issues using the accepted policy
+
+This stage should stabilize reporting before changing mutating behavior.
+
+### 5. Refactor mutating commands
+
+- `link`
+- `link --all`
+- `unlink`
+- `clean`
+- `promote`
+- `rename`
+
+For `promote` specifically:
+
+1. inspect authoring destination first
+2. use single-mirror fallback only when unambiguous
+3. fail hard on multiple local directories
+4. move to store
+5. relink to all configured destinations
+6. exit non-zero if any relink step fails
+
+### 6. Update CLI help and README
+
+- Explain central config path
+- Explain project config path
+- Explain authoring vs mirror destinations
+- Explain default tool behavior
+- Explain promotion workflow
+- Explain failure semantics for multi-destination operations
+- Include example configs
+
+### 7. Add tests before final handoff
+
+At minimum:
+
+- central config discovery at `~/.config/skill/config.yml`
+- config precedence between defaults, central config, and project config
+- default `codex` destination behavior
+- one authoring destination resolution
+- multi-destination linking
+- partial multi-destination conflict causing non-zero exit
+- unambiguous mirror fallback in `promote`
+- ambiguous `promote` failure on multiple local directories
+- `doctor` warnings for missing mirror destinations
+- `doctor` issues for authoring-destination problems
+- documentation-sensitive behavior reflected in CLI help text where appropriate
+
+### 8. Final validation
+
+Run the required quality gate:
+
+```sh
+make lint test
+```
+
+Do not hand off until it passes.
+
+## Recommended First Implementation Order
+
+When work resumes, take this order:
+
+1. Define central config file path and schema.
+2. Implement config merge and resolved layout.
+3. Add destination-state classification helper.
+4. Refactor `status` and `doctor` first.
+5. Refactor `link` and `unlink`.
+6. Refactor `promote`.
+7. Refactor `rename` and `clean`.
+8. Update README and tests.
+9. Run `make lint test`.
+
+## Handoff Summary
+
+The core design decision is:
+
+- one canonical store
+- one explicit authoring destination
+- zero or more mirror destinations
+- centralized tool preference config
+- project-level tool selection and overrides
+- one shared destination-state classifier
+
+Keep the implementation small, direct, and idiomatic Ruby 2.6.

--- a/skill/src/cli.rb
+++ b/skill/src/cli.rb
@@ -6,6 +6,7 @@ require_relative "skill/doctor"
 require_relative "skill/error"
 require_relative "skill/operations"
 require_relative "skill/paths"
+require_relative "skill/state"
 require_relative "skill/ui"
 
 module Skill
@@ -20,6 +21,7 @@ module Skill
       "adopt" => :run_adopt,
       "promote" => :run_promote,
       "rename" => :run_rename,
+      "config" => :run_config,
       "help" => :run_help
     }.freeze
 
@@ -33,7 +35,8 @@ module Skill
       "skill doctor",
       "skill adopt ../my-skill",
       "skill promote my-skill",
-      "skill rename ruby-dev ruby"
+      "skill rename ruby-dev ruby",
+      "skill config init"
     ].freeze
 
     def self.run(argv = ARGV)
@@ -81,7 +84,10 @@ module Skill
       puts <<~USAGE
         Usage: skill [--project PATH] <command> [args]
 
-        Manage symlinked Codex skills for a project using dotfiles as the canonical store.
+        Manage project skill links using dotfiles as the canonical store.
+
+        Central config: #{Skill::Config.central_config_path}
+        Project config: <project>/.skill.yml
 
         Commands:
           list                         List skills available in #{paths.store_dir}
@@ -92,8 +98,9 @@ module Skill
           clean                        Remove broken symlinks from the project
           doctor                       Diagnose project skill links and local copies
           adopt <path> [name]          Move a local skill directory into dotfiles and link it here
-          promote <name>               Move project .codex/skills/<name> into dotfiles and relink it
+          promote <name>               Move the project-local skill into dotfiles and relink it
           rename <old> <new>           Rename a stored skill and update this project's symlink if needed
+          config init                  Initialize ~/.config/skill/config.yml from the bundled template
           help                         Show this help
 
         Options:
@@ -160,6 +167,14 @@ module Skill
     def run_help(args)
       ui.reject_extra_args("help", args)
       usage
+    end
+
+    def run_config(args)
+      raise ExitError, "config requires a subcommand" if args.empty?
+      raise ExitError, "unknown config subcommand: #{args.first}" unless args.first == "init"
+      raise ExitError, "config init does not accept extra arguments" unless args.length == 1
+
+      operations.init_config
     end
 
     def parse_args(argv)

--- a/skill/src/cli.rb
+++ b/skill/src/cli.rb
@@ -6,7 +6,6 @@ require_relative "skill/doctor"
 require_relative "skill/error"
 require_relative "skill/operations"
 require_relative "skill/paths"
-require_relative "skill/state"
 require_relative "skill/ui"
 
 module Skill

--- a/skill/src/skill/config.rb
+++ b/skill/src/skill/config.rb
@@ -48,8 +48,9 @@ module Skill
 
     def self.central_config_path(env = ENV)
       xdg_config_home = env["XDG_CONFIG_HOME"]
+      home_dir = env["HOME"] || ENV["HOME"] || File.expand_path("~")
       base_dir = if xdg_config_home.nil? || xdg_config_home.empty?
-                   File.join(File.expand_path("~"), ".config")
+                   File.join(home_dir, ".config")
                  else
                    File.expand_path(xdg_config_home)
                  end
@@ -265,7 +266,18 @@ module Skill
     end
 
     def deep_copy(hash)
-      Marshal.load(Marshal.dump(hash))
+      case hash
+      when Hash
+        hash.each_with_object({}) do |(key, value), result|
+          result[deep_copy(key)] = deep_copy(value)
+        end
+      when Array
+        hash.map { |value| deep_copy(value) }
+      when String
+        hash.dup
+      else
+        hash
+      end
     end
 
     def blank?(value)

--- a/skill/src/skill/config.rb
+++ b/skill/src/skill/config.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Skill
+  class Config
+    DEFAULT_STORE_DIR = "skills"
+    CENTRAL_ALLOWED_KEYS = %w[defaults ignore required store_dir tools].freeze
+    PROJECT_ALLOWED_KEYS = %w[authoring_tool extra_destinations ignore required tools].freeze
+    DEFAULTS_ALLOWED_KEYS = %w[authoring_tool tools].freeze
+    TOOL_PROFILE_ALLOWED_KEYS = %w[authoring destinations].freeze
+    DEFAULT_TOOL_PROFILES = {
+      "codex" => {
+        "destinations" => [".codex/skills"],
+        "authoring" => true
+      }
+    }.freeze
+    DEFAULT_TOOLS = ["codex"].freeze
+
+    attr_reader :active_tools,
+                :authoring_destination,
+                :authoring_tool,
+                :central_config_path,
+                :destinations,
+                :ignored,
+                :mirror_destinations,
+                :project_config_path,
+                :required,
+                :store_dir
+
+    def self.load(project_root, dotfiles_root, env = ENV)
+      central_path = central_config_path(env)
+      project_path = File.join(project_root, ".skill.yml")
+
+      new(
+        dotfiles_root: dotfiles_root,
+        project_root: project_root,
+        central: {
+          path: central_path,
+          data: load_yaml(central_path)
+        },
+        project: {
+          path: project_path,
+          data: load_yaml(project_path)
+        }
+      )
+    end
+
+    def self.central_config_path(env = ENV)
+      xdg_config_home = env["XDG_CONFIG_HOME"]
+      base_dir = if xdg_config_home.nil? || xdg_config_home.empty?
+                   File.join(File.expand_path("~"), ".config")
+                 else
+                   File.expand_path(xdg_config_home)
+                 end
+
+      File.join(base_dir, "skill", "config.yml")
+    end
+
+    def self.load_yaml(path)
+      return {} unless File.exist?(path)
+
+      data = YAML.safe_load(File.read(path))
+      return {} if data.nil?
+      return data if data.is_a?(Hash)
+
+      raise ExitError, "invalid YAML in #{path}: expected a mapping at the top level"
+    rescue Psych::SyntaxError => e
+      raise ExitError, "invalid YAML in #{path}: #{e.message}"
+    end
+
+    def initialize(dotfiles_root:, project_root:, central:, project:)
+      @dotfiles_root = dotfiles_root
+      @project_root = project_root
+      @central_config_path = central[:path]
+      @project_config_path = project[:path]
+      @central_data = validate_mapping(central[:data], @central_config_path, CENTRAL_ALLOWED_KEYS)
+      @project_data = validate_mapping(project[:data], @project_config_path, PROJECT_ALLOWED_KEYS)
+
+      @store_dir = resolve_store_dir
+      @required = unique_strings(string_list(@central_data, "required", @central_config_path),
+                                 string_list(@project_data, "required", @project_config_path))
+      @ignored = unique_strings(string_list(@central_data, "ignore", @central_config_path),
+                                string_list(@project_data, "ignore", @project_config_path))
+
+      profiles = resolve_tool_profiles
+      @active_tools = resolve_active_tools(profiles)
+      @authoring_tool = resolve_authoring_tool(profiles)
+      @destinations = resolve_destinations(profiles)
+      @authoring_destination = resolve_authoring_destination(profiles)
+      @mirror_destinations = @destinations.reject { |dest| dest == @authoring_destination }
+    end
+
+    def ignored?(name)
+      @ignored.include?(name)
+    end
+
+    private
+
+    def resolve_store_dir
+      raw_store_dir = string_value(@central_data, "store_dir", @central_config_path) || DEFAULT_STORE_DIR
+      expanded = File.expand_path(raw_store_dir.to_s)
+      return expanded if path_absolute?(raw_store_dir.to_s)
+
+      File.expand_path(raw_store_dir.to_s, @dotfiles_root)
+    end
+
+    def resolve_tool_profiles
+      profiles = deep_copy(DEFAULT_TOOL_PROFILES)
+      custom_profiles = @central_data["tools"]
+      return profiles unless custom_profiles.is_a?(Hash)
+
+      custom_profiles.each do |name, raw_profile|
+        normalized_name = name.to_s
+        profile_path = "#{@central_config_path}:tools.#{normalized_name}"
+        profile_data = validate_mapping(raw_profile, profile_path, TOOL_PROFILE_ALLOWED_KEYS)
+        existing = profiles[normalized_name] || {}
+        profiles[normalized_name] = {
+          "destinations" => normalize_destinations(
+            profile_data.key?("destinations") ? profile_data["destinations"] : existing["destinations"],
+            profile_path
+          ),
+          "authoring" => truthy?(profile_data.key?("authoring") ? profile_data["authoring"] : existing["authoring"],
+                                 "#{profile_path}.authoring")
+        }
+      end
+
+      profiles
+    end
+
+    def resolve_active_tools(profiles)
+      defaults = defaults_data
+      tools = string_list(@project_data, "tools", @project_config_path)
+      tools = string_list(defaults, "tools", "#{@central_config_path}:defaults") if tools.empty?
+      tools = DEFAULT_TOOLS if tools.empty?
+      raise ExitError, "no active tools configured" if tools.empty?
+
+      unknown = tools.reject { |name| profiles.key?(name) }
+      raise ExitError, "unknown configured tool(s): #{unknown.sort.join(', ')}" unless unknown.empty?
+
+      tools
+    end
+
+    def resolve_authoring_tool(profiles)
+      raw_authoring = string_value(@project_data, "authoring_tool", @project_config_path)
+      if blank?(raw_authoring)
+        raw_authoring = string_value(defaults_data, "authoring_tool", "#{@central_config_path}:defaults")
+      end
+
+      authoring_tool = raw_authoring.to_s unless blank?(raw_authoring)
+      if blank?(authoring_tool)
+        authoring_tool = @active_tools.find { |name| truthy?(profiles.fetch(name, {})["authoring"]) }
+      end
+      authoring_tool = @active_tools.first if blank?(authoring_tool)
+
+      unless @active_tools.include?(authoring_tool)
+        raise ExitError, "authoring tool is not active for this project: #{authoring_tool}"
+      end
+
+      authoring_tool
+    end
+
+    def resolve_destinations(profiles)
+      destinations = []
+
+      @active_tools.each do |tool_name|
+        tool_destinations = profiles.fetch(tool_name, {})["destinations"]
+        destinations.concat(normalize_destinations(tool_destinations, "tool profile #{tool_name}"))
+      end
+
+      destinations.concat(normalize_destinations(@project_data["extra_destinations"],
+                                                 "#{@project_config_path}:extra_destinations"))
+      destinations = unique_strings(destinations)
+
+      raise ExitError, "no project skill destinations configured" if destinations.empty?
+
+      destinations
+    end
+
+    def resolve_authoring_destination(profiles)
+      authoring_profile = profiles.fetch(@authoring_tool, {})
+      tool_destinations = normalize_destinations(authoring_profile["destinations"],
+                                                 "tool profile #{@authoring_tool}")
+
+      destination = tool_destinations.first
+      raise ExitError, "authoring tool has no destinations configured: #{@authoring_tool}" if blank?(destination)
+
+      destination
+    end
+
+    def defaults_data
+      @defaults_data ||= validate_mapping(@central_data.fetch("defaults", {}),
+                                          "#{@central_config_path}:defaults",
+                                          DEFAULTS_ALLOWED_KEYS)
+    end
+
+    def validate_mapping(data, path, allowed_keys)
+      raise ExitError, "invalid config at #{path}: expected a mapping" unless data.is_a?(Hash)
+
+      normalized = {}
+      data.each do |key, value|
+        normalized[key.to_s] = value
+      end
+
+      unknown_keys = normalized.keys - allowed_keys
+      return normalized if unknown_keys.empty?
+
+      raise ExitError, "unknown config key(s) in #{path}: #{unknown_keys.sort.join(', ')}"
+    end
+
+    def string_list(data, key, path)
+      value = data[key]
+      return [] if value.nil?
+      raise ExitError, "invalid config at #{path}: #{key} must be an array of strings" unless value.is_a?(Array)
+
+      value.each_with_index.map do |item, index|
+        string_item(item, "#{path}:#{key}[#{index}]")
+      end
+    end
+
+    def string_value(data, key, path)
+      value = data[key]
+      return nil if value.nil?
+
+      string_item(value, "#{path}:#{key}")
+    end
+
+    def normalize_destinations(destinations, path)
+      return [] if destinations.nil?
+      unless destinations.is_a?(Array)
+        raise ExitError, "invalid config at #{path}: destinations must be an array of strings"
+      end
+
+      destinations.each_with_index.map do |destination, index|
+        string_item(destination, "#{path}:destinations[#{index}]")
+      end
+    end
+
+    def unique_strings(*values)
+      seen = {}
+
+      values.flatten.compact.map(&:to_s).reject(&:empty?).each_with_object([]) do |value, items|
+        next if seen.key?(value)
+
+        seen[value] = true
+        items << value
+      end
+    end
+
+    def string_item(value, path)
+      raise ExitError, "invalid config at #{path}: expected a string" unless value.is_a?(String)
+
+      item = value.strip
+      raise ExitError, "invalid config at #{path}: value must not be empty" if item.empty?
+
+      item
+    end
+
+    def truthy?(value, path = nil)
+      return value if [true, false].include?(value)
+      return false if value.nil?
+      raise ExitError, "invalid config boolean value: #{value.inspect}" if path.nil?
+
+      raise ExitError, "invalid config at #{path}: expected true or false"
+    end
+
+    def deep_copy(hash)
+      Marshal.load(Marshal.dump(hash))
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.empty?
+    end
+
+    def path_absolute?(path)
+      path.start_with?("/", "~")
+    end
+  end
+end

--- a/skill/src/skill/doctor.rb
+++ b/skill/src/skill/doctor.rb
@@ -45,7 +45,11 @@ module Skill
             puts("issue\tbroken symlink #{entry[:name]} -> #{entry[:target]} in #{dir}")
             issues += 1
           when :symlink_elsewhere
-            puts("issue\tsymlink outside store #{entry[:name]} -> #{entry[:target]} in #{dir}")
+            if inside_store?(entry[:resolved_target])
+              puts("issue\tsymlink to different stored skill #{entry[:name]} -> #{entry[:target]} in #{dir}")
+            else
+              puts("issue\tsymlink outside store #{entry[:name]} -> #{entry[:target]} in #{dir}")
+            end
             issues += 1
           when :local_directory
             puts("issue\tlocal directory still present #{entry[:name]} in #{dir}")
@@ -77,6 +81,12 @@ module Skill
 
       @shell_ui.note("doctor found #{issues} issue(s), #{warnings} warning(s)")
       raise ExitError.new(status: 1) unless issues.zero?
+    end
+
+    private
+
+    def inside_store?(path)
+      Filesystem.within_directory?(path, @paths.store_dir)
     end
   end
 end

--- a/skill/src/skill/doctor.rb
+++ b/skill/src/skill/doctor.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require_relative "filesystem"
+require_relative "state"
 
 module Skill
   class Doctor
     def initialize(paths:, shell_ui:)
       @paths = paths
       @shell_ui = shell_ui
+    end
+
+    def state
+      @state ||= State.new(paths: @paths)
     end
 
     def run
@@ -17,54 +22,52 @@ module Skill
 
       @shell_ui.note("project: #{@paths.project_root}")
       @shell_ui.note("store: #{@paths.store_dir}")
+      @shell_ui.note("authoring destination: #{@paths.project_skills_dir}")
 
-      unless Dir.exist?(@paths.project_skills_dir)
-        puts("warning\tmissing project skill directory #{@paths.project_skills_dir}")
-        warnings += 1
-        @shell_ui.note("doctor found #{issues} issue(s), #{warnings} warning(s)")
-        return
-      end
-
-      @paths.project_entries.each do |name|
-        path = @paths.project_skill_path(name)
-
-        if File.symlink?(path)
-          target = File.readlink(path)
-          resolved_target = Filesystem.symlink_target_path(path)
-
-          unless File.exist?(path)
-            puts("issue\tbroken symlink #{name} -> #{target}")
+      @paths.project_skills_dirs.each do |dir|
+        @shell_ui.note("checking: #{dir}")
+        unless Dir.exist?(dir)
+          if dir == @paths.project_skills_dir
+            puts("issue\tmissing authoring skill directory #{dir}")
             issues += 1
-            next
-          end
-
-          if inside_store?(resolved_target)
-            if File.basename(resolved_target) != name
-              puts("issue\tname mismatch #{name} -> #{target}")
-              issues += 1
-            else
-              puts("ok\tlinked #{name}")
-            end
           else
-            puts("issue\tsymlink outside store #{name} -> #{target}")
+            puts("warning\tmissing project skill directory #{dir}")
+            warnings += 1
+          end
+          next
+        end
+
+        state.inspect_destination_entries(dir).each do |entry|
+          case entry[:kind]
+          when :symlink_to_store
+            puts("ok\tlinked #{entry[:name]} in #{dir}")
+          when :broken_symlink
+            puts("issue\tbroken symlink #{entry[:name]} -> #{entry[:target]} in #{dir}")
+            issues += 1
+          when :symlink_elsewhere
+            puts("issue\tsymlink outside store #{entry[:name]} -> #{entry[:target]} in #{dir}")
+            issues += 1
+          when :local_directory
+            puts("issue\tlocal directory still present #{entry[:name]} in #{dir}")
+            issues += 1
+          when :foreign_file
+            puts("issue\tnon-directory path present #{entry[:name]} in #{dir}")
             issues += 1
           end
-        elsif File.directory?(path)
-          puts("issue\tlocal directory still present #{name}")
-          issues += 1
-        else
-          puts("issue\tnon-directory path present #{name}")
-          issues += 1
         end
-      end
 
-      @paths.store_skill_names.each do |name|
-        path = @paths.store_skill_path(name)
-        link_path = @paths.project_skill_path(name)
-        next if Filesystem.symlink_points_to?(link_path, path)
+        @paths.store_skill_names.each do |name|
+          entry = state.inspect_destination_skill(dir, name, @paths.store_skill_path(name))
+          next if entry[:kind] == :symlink_to_store
 
-        puts("warning\tstored skill not linked in project #{name}")
-        warnings += 1
+          if @paths.config.required.include?(name)
+            puts("issue\trequired skill not linked in project #{name} in #{dir}")
+            issues += 1
+          else
+            puts("warning\tstored skill not linked in project #{name} in #{dir}")
+            warnings += 1
+          end
+        end
       end
 
       if issues.zero? && warnings.zero?
@@ -74,12 +77,6 @@ module Skill
 
       @shell_ui.note("doctor found #{issues} issue(s), #{warnings} warning(s)")
       raise ExitError.new(status: 1) unless issues.zero?
-    end
-
-    private
-
-    def inside_store?(resolved_target)
-      Filesystem.within_directory?(resolved_target, @paths.store_dir)
     end
   end
 end

--- a/skill/src/skill/filesystem.rb
+++ b/skill/src/skill/filesystem.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 require_relative "error"
 
 module Skill
@@ -27,9 +29,21 @@ module Skill
     end
 
     def normalized_path(path)
-      File.realpath(path)
+      expanded = File.expand_path(path)
+      File.realpath(expanded)
     rescue StandardError
-      File.expand_path(path)
+      parent = File.dirname(expanded)
+      begin
+        File.join(File.realpath(parent), File.basename(expanded))
+      rescue StandardError
+        expanded
+      end
+    end
+
+    def create_symlink(target, link_path)
+      link_dir = File.dirname(link_path)
+      relative_target = Pathname.new(normalized_path(target)).relative_path_from(Pathname.new(link_dir))
+      File.symlink(relative_target.to_s, link_path)
     end
   end
 end

--- a/skill/src/skill/operations.rb
+++ b/skill/src/skill/operations.rb
@@ -121,6 +121,8 @@ module Skill
     end
 
     def clean_links
+      failures = []
+
       @paths.project_skills_dirs.each do |dir|
         unless Dir.exist?(dir)
           @shell_ui.note("nothing to clean; missing #{dir}")
@@ -143,8 +145,9 @@ module Skill
         end
 
         @shell_ui.note("no broken symlinks found in #{dir}") if cleaned.zero?
-        raise ExitError, "failed to clean #{failures.length} broken symlink(s) in #{dir}" unless failures.empty?
       end
+
+      raise ExitError, "failed to clean #{failures.length} broken symlink(s)" unless failures.empty?
     end
 
     def promote_skill(name)

--- a/skill/src/skill/operations.rb
+++ b/skill/src/skill/operations.rb
@@ -4,12 +4,17 @@ require "fileutils"
 
 require_relative "error"
 require_relative "filesystem"
+require_relative "state"
 
 module Skill
   class Operations
     def initialize(paths:, shell_ui:)
       @paths = paths
       @shell_ui = shell_ui
+    end
+
+    def state
+      @state ||= State.new(paths: @paths)
     end
 
     def list_store_skills
@@ -26,57 +31,56 @@ module Skill
     def show_status
       @shell_ui.note("project: #{@paths.project_root}")
       @shell_ui.note("store: #{@paths.store_dir}")
+      @shell_ui.note("authoring destination: #{@paths.project_skills_dir}")
 
-      unless Dir.exist?(@paths.project_skills_dir)
-        @shell_ui.note("project skill directory does not exist: #{@paths.project_skills_dir}")
-        return
-      end
+      @paths.project_skills_dirs.each do |dir|
+        @shell_ui.note("checking: #{dir}")
+        unless Dir.exist?(dir)
+          @shell_ui.note("  project skill directory does not exist: #{dir}")
+          next
+        end
 
-      entries = @paths.project_entries
-      if entries.empty?
-        @shell_ui.note("no project skills found in #{@paths.project_skills_dir}")
-        return
-      end
+        entries = state.inspect_destination_entries(dir)
+        if entries.empty?
+          @shell_ui.note("  no project skills found in #{dir}")
+          next
+        end
 
-      entries.each do |name|
-        path = @paths.project_skill_path(name)
-
-        if File.symlink?(path)
-          target = File.readlink(path)
-          state = File.exist?(path) ? "linked" : "broken"
-          puts("#{state}\t#{name} -> #{target}")
-        elsif File.directory?(path)
-          puts("local\t#{name}")
-        else
-          puts("file\t#{name}")
+        entries.each do |entry|
+          puts("  #{status_label(entry)}\t#{entry[:name]}#{status_suffix(entry)}")
         end
       end
     end
 
     def link_one(name)
       @paths.ensure_store!
-      @paths.ensure_project_skills_dir!
+      @paths.ensure_project_skills_dirs!
       Filesystem.assert_skill_name!(name)
 
       source = @paths.store_skill_path(name)
-      target = @paths.project_skill_path(name)
-
       raise ExitError, "stored skill not found: #{source}" unless File.directory?(source)
 
-      if File.symlink?(target)
-        current = File.readlink(target)
-        if Filesystem.symlink_points_to?(target, source)
-          @shell_ui.note("already linked: #{name}")
-          return
+      failures = []
+      state.inspect_skill(name).each do |entry|
+        case entry[:kind]
+        when :missing
+          Filesystem.create_symlink(source, entry[:path])
+          @shell_ui.note("linked #{name} -> #{source} in #{entry[:destination]}")
+        when :symlink_to_store
+          @shell_ui.note("already linked: #{name} in #{entry[:destination]}")
+        when :symlink_elsewhere
+          @shell_ui.note("refusing to replace existing symlink: #{entry[:path]} -> #{entry[:target]}")
+          failures << entry[:path]
+        when :broken_symlink
+          @shell_ui.note("refusing to replace broken symlink: #{entry[:path]} -> #{entry[:target]}")
+          failures << entry[:path]
+        else
+          @shell_ui.note("refusing to replace existing path: #{entry[:path]}")
+          failures << entry[:path]
         end
-
-        raise ExitError, "refusing to replace existing symlink: #{target} -> #{current}"
       end
 
-      raise ExitError, "refusing to replace existing path: #{target}" if File.exist?(target)
-
-      File.symlink(source, target)
-      @shell_ui.note("linked #{name} -> #{source}")
+      raise ExitError, "failed to link #{name} in #{failures.length} destination(s)" unless failures.empty?
     end
 
     def link_all
@@ -92,79 +96,105 @@ module Skill
 
     def unlink_one(name)
       Filesystem.assert_skill_name!(name)
-      target = @paths.project_skill_path(name)
 
-      if File.symlink?(target)
-        File.delete(target)
-        @shell_ui.note("unlinked #{name}")
-        return
+      failures = []
+      state.inspect_skill(name).each do |entry|
+        case entry[:kind]
+        when :symlink_to_store
+          File.delete(entry[:path])
+          @shell_ui.note("unlinked #{name} from #{entry[:destination]}")
+        when :missing
+          @shell_ui.note("not linked: #{name} in #{entry[:destination]}")
+        when :symlink_elsewhere
+          @shell_ui.note("refusing to remove foreign symlink: #{entry[:path]} -> #{entry[:target]}")
+          failures << entry[:path]
+        when :broken_symlink
+          @shell_ui.note("refusing to remove broken symlink outside clean: #{entry[:path]} -> #{entry[:target]}")
+          failures << entry[:path]
+        else
+          @shell_ui.note("refusing to remove non-symlink path: #{entry[:path]}")
+          failures << entry[:path]
+        end
       end
 
-      raise ExitError, "refusing to remove non-symlink path: #{target}" if File.exist?(target)
-
-      @shell_ui.note("not linked: #{name}")
+      raise ExitError, "failed to unlink #{name} in #{failures.length} destination(s)" unless failures.empty?
     end
 
     def clean_links
-      unless Dir.exist?(@paths.project_skills_dir)
-        @shell_ui.note("nothing to clean; missing #{@paths.project_skills_dir}")
-        return
+      @paths.project_skills_dirs.each do |dir|
+        unless Dir.exist?(dir)
+          @shell_ui.note("nothing to clean; missing #{dir}")
+          next
+        end
+
+        cleaned = 0
+        failures = []
+        state.inspect_destination_entries(dir).each do |entry|
+          next unless entry[:kind] == :broken_symlink
+
+          if inside_store?(entry[:resolved_target])
+            File.delete(entry[:path])
+            @shell_ui.note("removed broken symlink #{entry[:name]} from #{dir}")
+            cleaned += 1
+          else
+            @shell_ui.note("refusing to remove broken symlink outside store: #{entry[:path]} -> #{entry[:target]}")
+            failures << entry[:path]
+          end
+        end
+
+        @shell_ui.note("no broken symlinks found in #{dir}") if cleaned.zero?
+        raise ExitError, "failed to clean #{failures.length} broken symlink(s) in #{dir}" unless failures.empty?
       end
-
-      cleaned = 0
-      @paths.project_entries.each do |name|
-        path = @paths.project_skill_path(name)
-        next unless File.symlink?(path)
-        next if File.exist?(path)
-
-        File.delete(path)
-        @shell_ui.note("removed broken symlink #{name}")
-        cleaned += 1
-      end
-
-      @shell_ui.note("no broken symlinks found") if cleaned.zero?
     end
 
     def promote_skill(name)
       @paths.ensure_store!
-      @paths.ensure_project_skills_dir!
+      @paths.ensure_project_skills_dirs!
       Filesystem.assert_skill_name!(name)
 
-      source = @paths.project_skill_path(name)
-      target = @paths.store_skill_path(name)
+      states = state.inspect_skill(name)
+      local_states = states.select { |entry| entry[:kind] == :local_directory }
+      if local_states.length > 1
+        local_paths = local_states.map { |entry| entry[:path] }.sort.join(", ")
+        raise ExitError, "multiple local skill directories found for promotion: #{local_paths}"
+      end
 
-      raise ExitError, "project skill not found: #{source}" unless File.exist?(source) || File.symlink?(source)
-
-      if File.symlink?(source)
-        current = File.readlink(source)
-        if Filesystem.symlink_points_to?(source, target)
+      if local_states.empty?
+        if states.any? { |entry| entry[:kind] == :symlink_to_store }
           @shell_ui.note("already promoted: #{name}")
           return
         end
 
-        raise ExitError, "refusing to promote existing symlink: #{source} -> #{current}"
+        raise ExitError, "project skill directory not found for promotion: #{name}"
       end
 
-      raise ExitError, "project skill must be a directory: #{source}" unless File.directory?(source)
+      source = local_states.first
+      if source[:destination] != @paths.project_skills_dir
+        @shell_ui.note("using mirror destination for promote fallback: #{source[:destination]}")
+      end
+
+      assert_linkable_destinations!(states, name, allow_local_path: source[:path])
+      target = @paths.store_skill_path(name)
       if File.exist?(target) || File.symlink?(target)
         raise ExitError, "destination already exists in dotfiles: #{target}"
       end
 
-      FileUtils.mv(source, target)
-      File.symlink(target, source)
+      FileUtils.mv(source[:path], target)
       @shell_ui.note("promoted #{name} -> #{target}")
+
+      link_one(name)
     end
 
     def adopt_skill(source_input, name = nil)
       @paths.ensure_store!
-      @paths.ensure_project_skills_dir!
+      @paths.ensure_project_skills_dirs!
 
       raise ExitError, "adopt requires a source path" if source_input.nil? || source_input.empty?
 
       name = File.basename(source_input) if name.nil? || name.empty?
       Filesystem.assert_skill_name!(name)
 
-      if source_input == name && File.directory?(@paths.project_skill_path(name))
+      if source_input == name && state.inspect_skill(name).any? { |entry| entry[:kind] == :local_directory }
         promote_skill(name)
         return
       end
@@ -178,65 +208,133 @@ module Skill
       raise ExitError, "source skill directory not found: #{source}" unless File.directory?(source)
 
       target = @paths.store_skill_path(name)
-      link_path = @paths.project_skill_path(name)
-
       if File.exist?(target) || File.symlink?(target)
         raise ExitError, "destination already exists in dotfiles: #{target}"
       end
 
-      if File.symlink?(link_path)
-        current = File.readlink(link_path)
-        if Filesystem.symlink_points_to?(link_path, target)
-          raise ExitError, "project already links #{name} to #{target}"
-        end
-
-        raise ExitError, "refusing to replace existing symlink: #{link_path} -> #{current}"
-      end
-
-      if File.exist?(link_path) && source != link_path
-        raise ExitError, "refusing to replace existing project path: #{link_path}"
-      end
+      allow_local_path = nil
+      states = state.inspect_skill(name)
+      match = states.find { |entry| entry[:kind] == :local_directory && same_path?(entry[:path], source) }
+      allow_local_path = match[:path] unless match.nil?
+      assert_linkable_destinations!(states, name, allow_local_path: allow_local_path)
 
       FileUtils.mv(source, target)
-      FileUtils.rm_rf(link_path) if File.exist?(link_path) || File.symlink?(link_path)
-      File.symlink(target, link_path)
       @shell_ui.note("adopted #{name} -> #{target}")
+
+      link_one(name)
     end
 
     def rename_skill(old_name, new_name)
       @paths.ensure_store!
-      @paths.ensure_project_skills_dir!
+      @paths.ensure_project_skills_dirs!
       Filesystem.assert_skill_name!(old_name)
       Filesystem.assert_skill_name!(new_name)
       raise ExitError, "old and new skill names are identical" if old_name == new_name
 
       old_target = @paths.store_skill_path(old_name)
       new_target = @paths.store_skill_path(new_name)
-      old_link = @paths.project_skill_path(old_name)
-      new_link = @paths.project_skill_path(new_name)
 
       raise ExitError, "stored skill not found: #{old_target}" unless File.directory?(old_target)
       if File.exist?(new_target) || File.symlink?(new_target)
         raise ExitError, "destination already exists in dotfiles: #{new_target}"
       end
-      if File.exist?(new_link) || File.symlink?(new_link)
-        raise ExitError, "destination already exists in project: #{new_link}"
+
+      state.inspect_skill(new_name).each do |entry|
+        next if entry[:kind] == :missing
+
+        raise ExitError, "destination already exists in project: #{entry[:path]}"
       end
 
-      linked_to_old_target = File.symlink?(old_link) && File.exist?(old_link) && File.identical?(old_link, old_target)
+      old_states = state.inspect_skill(old_name)
       FileUtils.mv(old_target, new_target)
+      @shell_ui.note("renamed #{old_name} -> #{new_name} in store")
 
-      if linked_to_old_target
-        File.delete(old_link)
-        File.symlink(new_target, new_link)
-        @shell_ui.note("updated project link #{old_name} -> #{new_name}")
-      elsif File.symlink?(old_link)
-        @shell_ui.note("stored skill renamed; project symlink left unchanged because it pointed elsewhere")
-      elsif File.exist?(old_link)
-        @shell_ui.note("stored skill renamed; project path #{old_link} left unchanged because it is not a symlink")
+      old_states.each do |entry|
+        new_link = File.join(entry[:destination], new_name)
+
+        case entry[:kind]
+        when :symlink_to_store
+          File.delete(entry[:path])
+          Filesystem.create_symlink(new_target, new_link)
+          @shell_ui.note("updated project link #{old_name} -> #{new_name} in #{entry[:destination]}")
+        when :symlink_elsewhere
+          @shell_ui.note("project symlink in #{entry[:destination]} left unchanged because it pointed elsewhere")
+        when :broken_symlink
+          @shell_ui.note("project symlink in #{entry[:destination]} left unchanged because it is broken")
+        when :local_directory, :foreign_file
+          @shell_ui.note("project path #{entry[:path]} left unchanged because it is not a symlink")
+        end
+      end
+    end
+
+    def init_config
+      target_path = @paths.config.central_config_path
+      source_path = @paths.config_template_path
+
+      raise ExitError, "config template not found: #{source_path}" unless File.file?(source_path)
+      raise ExitError, "config already exists: #{target_path}" if File.exist?(target_path) || File.symlink?(target_path)
+
+      FileUtils.mkdir_p(File.dirname(target_path))
+      FileUtils.cp(source_path, target_path)
+      @shell_ui.note("initialized config at #{target_path}")
+    end
+
+    private
+
+    def assert_linkable_destinations!(states, name, allow_local_path: nil)
+      failures = []
+
+      states.each do |entry|
+        next if entry[:kind] == :missing
+        next if entry[:kind] == :symlink_to_store
+        next if entry[:kind] == :local_directory && !allow_local_path.nil? && same_path?(entry[:path], allow_local_path)
+
+        failures << entry
       end
 
-      @shell_ui.note("renamed #{old_name} -> #{new_name}")
+      return if failures.empty?
+
+      failures.each do |entry|
+        case entry[:kind]
+        when :symlink_elsewhere
+          @shell_ui.note("refusing to replace existing symlink: #{entry[:path]} -> #{entry[:target]}")
+        when :broken_symlink
+          @shell_ui.note("refusing to replace broken symlink: #{entry[:path]} -> #{entry[:target]}")
+        else
+          @shell_ui.note("refusing to replace existing path: #{entry[:path]}")
+        end
+      end
+
+      raise ExitError, "failed to prepare #{name} in #{failures.length} destination(s)"
+    end
+
+    def same_path?(left, right)
+      Filesystem.normalized_path(left) == Filesystem.normalized_path(right)
+    end
+
+    def status_label(entry)
+      case entry[:kind]
+      when :broken_symlink
+        "broken"
+      when :symlink_elsewhere
+        "foreign"
+      when :local_directory
+        "local"
+      when :foreign_file
+        "file"
+      else
+        "linked"
+      end
+    end
+
+    def status_suffix(entry)
+      return "" unless %i[symlink_to_store symlink_elsewhere broken_symlink].include?(entry[:kind])
+
+      " -> #{entry[:target]}"
+    end
+
+    def inside_store?(path)
+      Filesystem.within_directory?(path, @paths.store_dir)
     end
   end
 end

--- a/skill/src/skill/paths.rb
+++ b/skill/src/skill/paths.rb
@@ -4,19 +4,27 @@ require "fileutils"
 require "open3"
 
 require_relative "error"
+require_relative "config"
 
 module Skill
   class Paths
-    attr_writer :project_root
-
     def initialize(dotfiles_root:, project_root: nil)
       @dotfiles_root = dotfiles_root
       @project_root = project_root
-      @project_skills_dir = nil
+      @config = nil
+    end
+
+    def project_root=(value)
+      @project_root = value
+      @config = nil
+    end
+
+    def config
+      @config ||= Config.load(project_root, @dotfiles_root)
     end
 
     def store_dir
-      File.join(@dotfiles_root, "skills")
+      config.store_dir
     end
 
     def project_root
@@ -31,7 +39,11 @@ module Skill
     end
 
     def project_skills_dir
-      @project_skills_dir = File.join(project_root, ".codex", "skills")
+      resolve_project_destination(config.authoring_destination)
+    end
+
+    def project_skills_dirs
+      config.destinations.map { |dest| resolve_project_destination(dest) }
     end
 
     def ensure_store!
@@ -40,16 +52,24 @@ module Skill
       raise ExitError, "skill store not found: #{store_dir}"
     end
 
-    def ensure_project_skills_dir!
-      FileUtils.mkdir_p(project_skills_dir)
+    def ensure_project_skills_dirs!
+      project_skills_dirs.each { |dir| FileUtils.mkdir_p(dir) }
     end
 
     def store_skill_path(name)
       File.join(store_dir, name)
     end
 
+    def config_template_path
+      File.join(@dotfiles_root, "skill", "config", "default-config.yml")
+    end
+
     def project_skill_path(name)
       File.join(project_skills_dir, name)
+    end
+
+    def project_skill_paths(name)
+      project_skills_dirs.map { |dir| File.join(dir, name) }
     end
 
     def store_skill_names
@@ -57,18 +77,23 @@ module Skill
 
       Dir.children(store_dir).sort.select do |name|
         next false if name.start_with?(".")
+        next false if config.ignored?(name)
 
         File.directory?(store_skill_path(name))
       end
     end
 
-    def project_entries
-      return [] unless Dir.exist?(project_skills_dir)
+    def project_entries(dir)
+      return [] unless Dir.exist?(dir)
 
-      Dir.entries(project_skills_dir).reject { |name| [".", ".."].include?(name) }.sort
+      Dir.entries(dir).reject { |name| [".", ".."].include?(name) }.sort
     end
 
     private
+
+    def resolve_project_destination(destination)
+      File.expand_path(destination, project_root)
+    end
 
     def capture_command(*command)
       output, status = Open3.capture2(*command, err: File::NULL)

--- a/skill/src/skill/state.rb
+++ b/skill/src/skill/state.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "filesystem"
+
+module Skill
+  class State
+    def initialize(paths:)
+      @paths = paths
+    end
+
+    def inspect_skill(name)
+      store_path = @paths.store_skill_path(name)
+
+      @paths.project_skills_dirs.map do |dir|
+        inspect_destination_skill(dir, name, store_path)
+      end
+    end
+
+    def inspect_destination_entries(dir)
+      @paths.project_entries(dir).map do |name|
+        store_path = @paths.store_skill_path(name)
+        store_path = nil unless File.directory?(store_path)
+        inspect_destination_skill(dir, name, store_path)
+      end
+    end
+
+    def inspect_destination_skill(dir, name, store_path = nil)
+      path = File.join(dir, name)
+      result = inspect_path(path, store_path)
+      result[:destination] = dir
+      result[:name] = name
+      result
+    end
+
+    def inspect_path(path, store_path = nil)
+      if File.symlink?(path)
+        target = File.readlink(path)
+        resolved_target = Filesystem.symlink_target_path(path)
+        normalized_store_path = Filesystem.normalized_path(store_path) unless store_path.nil?
+
+        if !File.exist?(path)
+          { path: path, kind: :broken_symlink, resolved_target: resolved_target, target: target }
+        elsif !normalized_store_path.nil? && resolved_target == normalized_store_path
+          { path: path, kind: :symlink_to_store, resolved_target: resolved_target, target: target }
+        else
+          { path: path, kind: :symlink_elsewhere, resolved_target: resolved_target, target: target }
+        end
+      elsif File.directory?(path)
+        { path: path, kind: :local_directory }
+      elsif File.exist?(path)
+        { path: path, kind: :foreign_file }
+      else
+        { path: path, kind: :missing }
+      end
+    end
+  end
+end

--- a/skill/test/cli_test.rb
+++ b/skill/test/cli_test.rb
@@ -171,6 +171,37 @@ class SkillCliTest < Minitest::Test
     assert(File.symlink?(broken_link))
   end
 
+  def test_clean_continues_across_destinations_before_failing
+    write_central_config(<<~YAML)
+      store_dir: #{@skills_dir}
+      tools:
+        codex:
+          destinations:
+            - .codex/skills
+          authoring: true
+        generic:
+          destinations:
+            - .skills
+      defaults:
+        tools:
+          - codex
+          - generic
+    YAML
+
+    removable_link = create_broken_link("missing")
+    foreign_link = File.join(@project_root, ".skills", "foreign")
+    FileUtils.mkdir_p(File.dirname(foreign_link))
+    File.symlink("../elsewhere/missing", foreign_link)
+
+    result = run_skill("clean")
+
+    assert_equal(1, result.exitstatus)
+    refute_path_exists(removable_link)
+    assert(File.symlink?(foreign_link))
+    assert_includes(result.output, "removed broken symlink missing")
+    assert_includes(result.output, "failed to clean 1 broken symlink(s)")
+  end
+
   def test_promote_moves_local_project_skill_into_store_and_relinks
     local_skill = File.join(@project_root, ".codex", "skills", "my-skill")
     FileUtils.mkdir_p(local_skill)
@@ -272,6 +303,19 @@ class SkillCliTest < Minitest::Test
     assert_equal(0, result.exitstatus)
     assert_includes(result.output, "ok\tlinked ruby-dev")
     assert_includes(result.output, "skill: doctor found no issues")
+  end
+
+  def test_doctor_reports_symlink_to_different_stored_skill
+    create_store_skill("ruby-dev")
+    create_store_skill("ruby")
+    link_path = File.join(@project_root, ".codex", "skills", "ruby-dev")
+    FileUtils.mkdir_p(File.dirname(link_path))
+    File.symlink(File.join(@skills_dir, "ruby"), link_path)
+
+    result = run_skill("doctor")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "issue\tsymlink to different stored skill ruby-dev")
   end
 
   def test_cli_file_runs_when_executed_directly

--- a/skill/test/cli_test.rb
+++ b/skill/test/cli_test.rb
@@ -14,17 +14,22 @@ class SkillCliTest < Minitest::Test
     @tmpdir = Dir.mktmpdir("skill-cli-test")
     @dotfiles_root = File.join(@tmpdir, "dotfiles")
     @project_root = File.join(@tmpdir, "project")
+    @home = File.join(@tmpdir, "home")
+    @xdg_config_home = File.join(@home, ".config")
     @script_path = File.join(@dotfiles_root, "scripts", "skill")
     @skill_root = File.join(@dotfiles_root, "skill")
     @skills_dir = File.join(@dotfiles_root, "skills")
     @cli_path = File.join(@skill_root, "src", "cli.rb")
 
+    FileUtils.mkdir_p(@xdg_config_home)
     FileUtils.mkdir_p(File.dirname(@script_path))
     FileUtils.mkdir_p(@skills_dir)
     FileUtils.mkdir_p(@skill_root)
+    FileUtils.mkdir_p(File.join(@skill_root, "config"))
 
     FileUtils.cp(File.expand_path("../../scripts/skill", __dir__), @script_path)
     FileUtils.cp_r(File.expand_path("../src", __dir__), @skill_root)
+    FileUtils.cp_r(File.expand_path("../config", __dir__), @skill_root)
     FileUtils.chmod("+x", @script_path)
 
     FileUtils.mkdir_p(@project_root)
@@ -69,6 +74,7 @@ class SkillCliTest < Minitest::Test
     assert_equal(1, result.exitstatus)
     assert(File.directory?(File.join(@project_root, ".codex", "skills", "ruby-dev")))
     refute(File.symlink?(File.join(@project_root, ".codex", "skills", "ruby-dev")))
+    assert_includes(result.output, "failed to link ruby-dev in 1 destination(s)")
   end
 
   def test_global_project_option_applies_to_mutating_commands
@@ -134,6 +140,7 @@ class SkillCliTest < Minitest::Test
     result = run_skill("status")
 
     assert_equal(0, result.exitstatus)
+    assert_includes(result.output, "authoring destination: #{File.realpath(@project_root)}/.codex/skills")
     assert_includes(result.output, "linked\truby-dev -> #{@skills_dir}/ruby-dev")
     assert_includes(result.output, "local\tlocal-skill")
     assert_includes(result.output, "file\tnotes.txt")
@@ -152,6 +159,18 @@ class SkillCliTest < Minitest::Test
     refute_path_exists(broken_link)
   end
 
+  def test_clean_refuses_to_remove_broken_symlink_outside_store
+    broken_link = File.join(@project_root, ".codex", "skills", "foreign")
+    FileUtils.mkdir_p(File.dirname(broken_link))
+    File.symlink("../elsewhere/missing", broken_link)
+
+    result = run_skill("clean")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "refusing to remove broken symlink outside store")
+    assert(File.symlink?(broken_link))
+  end
+
   def test_promote_moves_local_project_skill_into_store_and_relinks
     local_skill = File.join(@project_root, ".codex", "skills", "my-skill")
     FileUtils.mkdir_p(local_skill)
@@ -163,7 +182,10 @@ class SkillCliTest < Minitest::Test
     assert_includes(result.output, "promoted my-skill -> #{File.realpath(@skills_dir)}/my-skill")
     assert(File.directory?(File.join(@skills_dir, "my-skill")))
     assert(File.symlink?(local_skill))
-    assert_equal(File.join(File.realpath(@skills_dir), "my-skill"), File.readlink(local_skill))
+    store_skill = Pathname.new(File.join(File.realpath(@skills_dir), "my-skill"))
+    link_dir = Pathname.new(File.realpath(File.dirname(local_skill)))
+    expected_target = store_skill.relative_path_from(link_dir).to_s
+    assert_equal(expected_target, File.readlink(local_skill))
   end
 
   def test_rename_leaves_project_symlink_alone_when_it_points_elsewhere
@@ -177,7 +199,11 @@ class SkillCliTest < Minitest::Test
     result = run_skill("rename", "old-name", "new-name")
 
     assert_equal(0, result.exitstatus)
-    assert_includes(result.output, "stored skill renamed; project symlink left unchanged because it pointed elsewhere")
+    expected_note = [
+      "project symlink in #{File.realpath(@project_root)}/.codex/skills",
+      "left unchanged because it pointed elsewhere"
+    ].join(" ")
+    assert_includes(result.output, expected_note)
     assert_equal(File.join(@skills_dir, "other"), File.readlink(old_link))
     assert(File.directory?(File.join(@skills_dir, "new-name")))
   end
@@ -205,6 +231,33 @@ class SkillCliTest < Minitest::Test
     assert_includes(result.output, "doctor found 0 issue(s), 1 warning(s)")
   end
 
+  def test_doctor_missing_authoring_destination_is_an_issue
+    write_central_config(<<~YAML)
+      store_dir: #{@skills_dir}
+      tools:
+        codex:
+          destinations:
+            - .codex/skills
+          authoring: true
+        generic:
+          destinations:
+            - .skills
+      defaults:
+        tools:
+          - codex
+          - generic
+        authoring_tool: codex
+    YAML
+    create_store_skill("ruby-dev")
+    FileUtils.mkdir_p(File.join(@project_root, ".skills"))
+
+    result = run_skill("doctor")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "issue\tmissing authoring skill directory")
+    assert_includes(result.output, "warning\tstored skill not linked")
+  end
+
   def test_doctor_accepts_relative_symlink_into_store
     create_store_skill("ruby-dev")
     link_path = File.join(@project_root, ".codex", "skills", "ruby-dev")
@@ -223,6 +276,7 @@ class SkillCliTest < Minitest::Test
 
   def test_cli_file_runs_when_executed_directly
     output, status = Open3.capture2e(
+      default_env,
       RbConfig.ruby,
       @cli_path,
       "help",
@@ -231,12 +285,180 @@ class SkillCliTest < Minitest::Test
 
     assert_equal(0, status.exitstatus)
     assert_includes(output, "Usage: skill")
+    assert_includes(output, "Central config: #{@xdg_config_home}/skill/config.yml")
+  end
+
+  def test_central_config_can_link_into_multiple_destinations
+    write_central_config(<<~YAML)
+      store_dir: #{@skills_dir}
+      tools:
+        codex:
+          destinations:
+            - .codex/skills
+          authoring: true
+        generic:
+          destinations:
+            - .skills
+      defaults:
+        tools:
+          - codex
+          - generic
+    YAML
+    create_store_skill("ruby-dev")
+
+    result = run_skill("link", "ruby-dev")
+
+    assert_equal(0, result.exitstatus)
+    assert(File.symlink?(File.join(@project_root, ".codex", "skills", "ruby-dev")))
+    assert(File.symlink?(File.join(@project_root, ".skills", "ruby-dev")))
+  end
+
+  def test_status_marks_foreign_symlinks_as_foreign
+    create_store_skill("ruby-dev")
+    foreign_target = File.join(@project_root, "external-target")
+    FileUtils.mkdir_p(foreign_target)
+    foreign_link = File.join(@project_root, ".codex", "skills", "ruby-dev")
+    FileUtils.mkdir_p(File.dirname(foreign_link))
+    File.symlink(foreign_target, foreign_link)
+
+    result = run_skill("status")
+
+    assert_equal(0, result.exitstatus)
+    assert_includes(result.output, "foreign\truby-dev -> #{foreign_target}")
+  end
+
+  def test_config_init_writes_default_template
+    result = run_skill("config", "init")
+    config_path = File.join(@xdg_config_home, "skill", "config.yml")
+    template_path = File.join(@skill_root, "config", "default-config.yml")
+
+    assert_equal(0, result.exitstatus)
+    assert(File.exist?(config_path))
+    assert_equal(File.read(template_path), File.read(config_path))
+    assert_includes(result.output, "initialized config at #{config_path}")
+  end
+
+  def test_config_init_refuses_to_overwrite_existing_config
+    write_central_config("store_dir: skills\n")
+
+    result = run_skill("config", "init")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "config already exists:")
+  end
+
+  def test_config_requires_subcommand
+    result = run_skill("config")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "config requires a subcommand")
+  end
+
+  def test_config_rejects_unknown_subcommand
+    result = run_skill("config", "wat")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "unknown config subcommand: wat")
+  end
+
+  def test_config_init_rejects_extra_arguments
+    result = run_skill("config", "init", "extra")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "config init does not accept extra arguments")
+  end
+
+  def test_promote_uses_single_mirror_fallback_when_authoring_destination_is_missing
+    write_central_config(<<~YAML)
+      store_dir: #{@skills_dir}
+      tools:
+        codex:
+          destinations:
+            - .codex/skills
+          authoring: true
+        generic:
+          destinations:
+            - .skills
+      defaults:
+        tools:
+          - codex
+          - generic
+    YAML
+
+    mirror_skill = File.join(@project_root, ".skills", "mirror-skill")
+    FileUtils.mkdir_p(mirror_skill)
+    File.write(File.join(mirror_skill, "SKILL.md"), "# Mirror Skill\n")
+
+    result = run_skill("promote", "mirror-skill")
+
+    assert_equal(0, result.exitstatus)
+    fallback_note = "using mirror destination for promote fallback: #{File.realpath(@project_root)}/.skills"
+    assert_includes(result.output, fallback_note)
+    assert(File.directory?(File.join(@skills_dir, "mirror-skill")))
+    assert(File.symlink?(File.join(@project_root, ".codex", "skills", "mirror-skill")))
+    assert(File.symlink?(File.join(@project_root, ".skills", "mirror-skill")))
+  end
+
+  def test_promote_fails_when_multiple_destinations_have_local_skill_directories
+    write_central_config(<<~YAML)
+      store_dir: #{@skills_dir}
+      tools:
+        codex:
+          destinations:
+            - .codex/skills
+          authoring: true
+        generic:
+          destinations:
+            - .skills
+      defaults:
+        tools:
+          - codex
+          - generic
+    YAML
+
+    FileUtils.mkdir_p(File.join(@project_root, ".codex", "skills", "shared-skill"))
+    FileUtils.mkdir_p(File.join(@project_root, ".skills", "shared-skill"))
+
+    result = run_skill("promote", "shared-skill")
+
+    assert_equal(1, result.exitstatus)
+    assert_includes(result.output, "multiple local skill directories found for promotion")
+  end
+
+  def test_link_reports_partial_failure_after_linking_other_destinations
+    write_central_config(<<~YAML)
+      store_dir: #{@skills_dir}
+      tools:
+        codex:
+          destinations:
+            - .codex/skills
+          authoring: true
+        generic:
+          destinations:
+            - .skills
+      defaults:
+        tools:
+          - codex
+          - generic
+    YAML
+    create_store_skill("ruby-dev")
+    FileUtils.mkdir_p(File.join(@project_root, ".codex", "skills", "ruby-dev"))
+
+    result = run_skill("link", "ruby-dev")
+
+    assert_equal(1, result.exitstatus)
+    assert(File.directory?(File.join(@project_root, ".codex", "skills", "ruby-dev")))
+    assert(File.symlink?(File.join(@project_root, ".skills", "ruby-dev")))
+    linked_note = "linked ruby-dev -> #{@skills_dir}/ruby-dev in #{File.realpath(@project_root)}/.skills"
+    assert_includes(result.output, linked_note)
+    assert_includes(result.output, "failed to link ruby-dev in 1 destination(s)")
   end
 
   private
 
   def run_skill(*args)
     output, status = Open3.capture2e(
+      default_env,
       RbConfig.ruby,
       @script_path,
       *args,
@@ -244,6 +466,13 @@ class SkillCliTest < Minitest::Test
     )
 
     Result.new(output, status.exitstatus)
+  end
+
+  def default_env
+    {
+      "HOME" => @home,
+      "XDG_CONFIG_HOME" => @xdg_config_home
+    }
   end
 
   def create_store_skill(name)
@@ -270,5 +499,11 @@ class SkillCliTest < Minitest::Test
 
   def refute_path_exists(path)
     refute(File.exist?(path) || File.symlink?(path), "Expected #{path} to be absent")
+  end
+
+  def write_central_config(contents)
+    path = File.join(@xdg_config_home, "skill", "config.yml")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
   end
 end

--- a/skill/test/unit_test.rb
+++ b/skill/test/unit_test.rb
@@ -116,6 +116,14 @@ class SkillUnitTest < Minitest::Test
     assert_includes(config.destinations, ".skills")
   end
 
+  def test_central_config_path_uses_supplied_home_when_xdg_config_home_is_unset
+    env = { "HOME" => "/tmp/skill-home" }
+
+    path = Skill::Config.central_config_path(env)
+
+    assert_equal("/tmp/skill-home/.config/skill/config.yml", path)
+  end
+
   def test_config_loads_supported_project_config_shape
     fixture_path = File.expand_path("../test_project/.skill.yml", __dir__)
     FileUtils.cp(fixture_path, File.join(@project_root, ".skill.yml"))

--- a/skill/test/unit_test.rb
+++ b/skill/test/unit_test.rb
@@ -10,6 +10,7 @@ require_relative "../src/skill/doctor"
 require_relative "../src/skill/error"
 require_relative "../src/skill/operations"
 require_relative "../src/skill/paths"
+require_relative "../src/skill/state"
 
 class SkillUnitTest < Minitest::Test
   FakeUI = Struct.new(:notes) do
@@ -23,6 +24,8 @@ class SkillUnitTest < Minitest::Test
     @dotfiles_root = File.join(@tmpdir, "dotfiles")
     @project_root = File.join(@tmpdir, "project")
     @skills_dir = File.join(@dotfiles_root, "skills")
+    @original_home = ENV["HOME"]
+    @original_xdg_config_home = ENV["XDG_CONFIG_HOME"]
 
     FileUtils.mkdir_p(@skills_dir)
     FileUtils.mkdir_p(@project_root)
@@ -34,6 +37,8 @@ class SkillUnitTest < Minitest::Test
   end
 
   def teardown
+    ENV["HOME"] = @original_home
+    ENV["XDG_CONFIG_HOME"] = @original_xdg_config_home
     FileUtils.rm_rf(@tmpdir)
   end
 
@@ -78,10 +83,114 @@ class SkillUnitTest < Minitest::Test
     assert_includes(@ui.notes, "doctor found no issues")
   end
 
+  def test_config_prefers_xdg_config_home_central_config
+    home = File.join(@tmpdir, "home")
+    xdg_config_home = File.join(home, ".config")
+    FileUtils.mkdir_p(File.join(xdg_config_home, "skill"))
+    File.write(
+      File.join(xdg_config_home, "skill", "config.yml"),
+      <<~YAML
+        store_dir: #{@skills_dir}
+        tools:
+          codex:
+            destinations:
+              - .codex/skills
+            authoring: true
+          generic:
+            destinations:
+              - .skills
+        defaults:
+          tools:
+            - codex
+            - generic
+      YAML
+    )
+
+    ENV["HOME"] = home
+    ENV["XDG_CONFIG_HOME"] = xdg_config_home
+
+    config = Skill::Config.load(@project_root, @dotfiles_root)
+
+    assert_equal(%w[codex generic], config.active_tools)
+    assert_equal(".codex/skills", config.authoring_destination)
+    assert_includes(config.destinations, ".skills")
+  end
+
+  def test_config_loads_supported_project_config_shape
+    fixture_path = File.expand_path("../test_project/.skill.yml", __dir__)
+    FileUtils.cp(fixture_path, File.join(@project_root, ".skill.yml"))
+    write_central_config(
+      <<~YAML
+        store_dir: #{@skills_dir}
+        tools:
+          codex:
+            destinations:
+              - .codex/skills
+            authoring: true
+          github:
+            destinations:
+              - .github/skills
+        defaults:
+          tools:
+            - codex
+      YAML
+    )
+
+    config = Skill::Config.load(@project_root, @dotfiles_root)
+
+    assert_equal(%w[codex github], config.active_tools)
+    assert_equal(".codex/skills", config.authoring_destination)
+    assert_equal(%w[ruby-dev], config.required)
+    assert_equal(%w[secret-skill], config.ignored)
+    assert_includes(config.destinations, ".skills")
+    assert_includes(config.destinations, ".github/skills")
+  end
+
+  def test_config_rejects_unknown_project_keys
+    File.write(
+      File.join(@project_root, ".skill.yml"),
+      <<~YAML
+        destinations:
+          - .codex/skills
+        name_mappings:
+          ruby-dev: ruby
+      YAML
+    )
+
+    error = assert_raises(Skill::ExitError) do
+      Skill::Config.load(@project_root, @dotfiles_root)
+    end
+
+    assert_equal(1, error.status)
+    assert_includes(error.message, "unknown config key(s)")
+    assert_includes(error.message, "destinations")
+    assert_includes(error.message, "name_mappings")
+  end
+
+  def test_state_reports_broken_symlink_with_resolved_target
+    link_path = File.join(@project_root, ".codex", "skills", "ruby-dev")
+    FileUtils.mkdir_p(File.dirname(link_path))
+    File.symlink("../missing-target", link_path)
+
+    entry = Skill::State.new(paths: @paths).inspect_destination_skill(@paths.project_skills_dir, "ruby-dev")
+
+    assert_equal(:broken_symlink, entry[:kind])
+    assert_includes(entry[:resolved_target], "missing-target")
+  end
+
   private
 
   def create_store_skill(name)
     FileUtils.mkdir_p(File.join(@skills_dir, name))
+  end
+
+  def write_central_config(contents)
+    config_path = File.join(@tmpdir, "home", ".config", "skill", "config.yml")
+    FileUtils.mkdir_p(File.dirname(config_path))
+    File.write(config_path, contents)
+
+    ENV["HOME"] = File.join(@tmpdir, "home")
+    ENV["XDG_CONFIG_HOME"] = File.join(@tmpdir, "home", ".config")
   end
 
   def capture_output

--- a/skill/test_project/.skill.yml
+++ b/skill/test_project/.skill.yml
@@ -1,0 +1,9 @@
+tools:
+  - codex
+  - github
+extra_destinations:
+  - .skills
+required:
+  - ruby-dev
+ignore:
+  - secret-skill


### PR DESCRIPTION
Summary
- add central and project-local config for skill destinations
- support authoring plus mirror destinations with safer state handling
- add skill config init and update docs/tests for the new workflow

Root Cause
- the skill CLI was hardcoded to a single .codex/skills destination and had no bootstrap path for central configuration

Fix
- add configurable destination resolution and shared destination-state inspection
- harden link, clean, doctor, promote, rename, and config bootstrap behavior
- document and test multi-destination, onboarding, and failure-policy behavior

Validation
- ruby -Iskill/test -e 'Dir["skill/test/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
- make lint test

Ticket
- none