### PR TITLE
feat(scripts): improve playground (`pg`) workflow w/ picker UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`; macOS `open` for Finder shortcut.                              |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `O` to open the highlighted folder in Finder.      | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This repository contains config files to set up my systems and keep them in sync
 
 ### Quick-start tools
 
-| Script                           | What it does                                                                                                            | Prerequisites                                                         |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `./scripts/macos-defaults-apply` | Guided wizard that applies my preferred macOS defaults and prompts for the manual tweaks listed below.                  | macOS, `sudo` access for protected settings.                          |
-| `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                           | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
-| `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files. | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
-| `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.         | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
+| Script                           | What it does                                                                                                                | Prerequisites                                                         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `./scripts/macos-defaults-apply` | Guided wizard that applies my preferred macOS defaults and prompts for the manual tweaks listed below.                      | macOS, `sudo` access for protected settings.                          |
+| `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
+| `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
+| `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
 | `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`; macOS `open` for Finder shortcut.                              |
 
 ## Codex Skills

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `O` to open the highlighted folder in Finder.      | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Alt-O` to open the highlighted folder in Finder.  | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `O` to open the highlighted folder in Finder.      | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                           | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files. | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.         | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `O` to open the highlighted folder in Finder.  | `fzf`; macOS `open` for Finder shortcut.                              |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`; macOS `open` for Finder shortcut.                              |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `O` to open the highlighted folder in Finder.      | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`; macOS `open` for Finder shortcut.                              |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Alt-O` to open the highlighted folder in Finder.  | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                               | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files.     | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.             | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
-| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`; macOS `open` for Finder shortcut.                              |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `Ctrl-O` to open the highlighted folder in Finder. | `fzf`, `rg`; macOS `open` for Finder shortcut.                        |
 
 ## Codex Skills
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository contains config files to set up my systems and keep them in sync
 | `./scripts/wiki`                 | `fzf`-powered browser for the local wiki directory that opens files in your preferred editor.                           | `fzf`, `git`, `rg`, optional `VISUAL`/`EDITOR` or `WIKI_*` overrides. |
 | `./scripts/download-audio`       | Fetches remote audio (e.g., YouTube URLs) and normalises them via the `process-audio` pipeline for library-ready files. | `aria2`, `ffmpeg`, `yt-dlp`; installs live in the Brewfile.           |
 | `./scripts/skill`                | Links project `.codex/skills` entries to the canonical `~/.dotfiles/skills` store and can promote local skills.         | Ruby 2.6+, optional `git` for auto-detecting the project root.        |
+| `./scripts/playground`           | Picks or creates playground projects for `pg`; interactive mode supports `O` to open the highlighted folder in Finder.  | `fzf`; macOS `open` for Finder shortcut.                              |
 
 ## Codex Skills
 

--- a/profile
+++ b/profile
@@ -1,6 +1,16 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
 #: Helper functions {{{
+playground() {
+  local target
+  target="$(command playground "$@")" || return $?
+
+  cd "$target" || {
+    echo "playground: unable to change directory to $target" >&2
+    return 1
+  }
+}
+
 function command_exists {
   type "$1" >/dev/null 2>&1;
 }

--- a/profile
+++ b/profile
@@ -2,14 +2,14 @@
 
 #: Helper functions {{{
 function pg {
-  playground_path_cmd="$HOME/.dotfiles/scripts/playground-path"
+  playground_cmd="$HOME/.dotfiles/scripts/playground"
 
-  if [ ! -x "$playground_path_cmd" ]; then
-    echo "pg: expected executable at $playground_path_cmd" >&2
+  if [ ! -x "$playground_cmd" ]; then
+    echo "pg: expected executable at $playground_cmd" >&2
     return 127
   fi
 
-  dir="$("$playground_path_cmd" "$@")" || return $?
+  dir="$("$playground_cmd" "$@")" || return $?
   cd "$dir" || {
     echo "pg: unable to change directory to $dir" >&2
     return 1

--- a/profile
+++ b/profile
@@ -1,25 +1,6 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
 #: Helper functions {{{
-function pg {
-  playground_cmd="$HOME/.dotfiles/scripts/playground"
-
-  if [ ! -x "$playground_cmd" ]; then
-    echo "pg: expected executable at $playground_cmd" >&2
-    return 127
-  fi
-
-  dir="$("$playground_cmd" "$@")" || return $?
-  cd "$dir" || {
-    echo "pg: unable to change directory to $dir" >&2
-    return 1
-  }
-}
-
-function playground {
-  pg "$@"
-}
-
 function command_exists {
   type "$1" >/dev/null 2>&1;
 }

--- a/profile
+++ b/profile
@@ -1,11 +1,23 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
 #: Helper functions {{{
-function playground {
-  dir="$HOME/playground/$(date -u +'%Y-%m')"
+function pg {
+  playground_path_cmd="$HOME/.dotfiles/scripts/playground-path"
 
-  [ ! -d "$dir" ] && mkdir -p "$dir"
-  cd "$dir" || echo "Playground: unable to change directory to $dir"
+  if [ ! -x "$playground_path_cmd" ]; then
+    echo "pg: expected executable at $playground_path_cmd" >&2
+    return 127
+  fi
+
+  dir="$("$playground_path_cmd" "$@")" || return $?
+  cd "$dir" || {
+    echo "pg: unable to change directory to $dir" >&2
+    return 1
+  }
+}
+
+function playground {
+  pg "$@"
 }
 
 function command_exists {

--- a/profile
+++ b/profile
@@ -1,16 +1,6 @@
 # vim:fileencoding=utf-8:ft=conf:foldmethod=marker
 
 #: Helper functions {{{
-playground() {
-  local target
-  target="$(command playground "$@")" || return $?
-
-  cd "$target" || {
-    echo "playground: unable to change directory to $target" >&2
-    return 1
-  }
-}
-
 function command_exists {
   type "$1" >/dev/null 2>&1;
 }

--- a/scripts/playground
+++ b/scripts/playground
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# playground-path
+# playground
 #
 # Prints a target directory for shell wrappers to `cd` into.
-# - playground-path <name>      => current UTC month project path
-# - playground-path             => interactive fzf picker (latest first)
-# - playground-path --preview <absolute_project_path>
+# - playground <name> => current UTC month project path
+# - playground        => interactive fzf picker (latest first)
+# - playground --help => usage
 
 set -euo pipefail
 
@@ -14,13 +14,18 @@ month="$(date -u +'%Y-%m')"
 month_dir="${root}/${month}"
 
 usage() {
-  echo "usage: playground-path [project_name]" >&2
+  cat <<'EOF'
+Usage:
+  playground             Interactive picker for existing projects
+  playground <name>      Create/select project in current UTC month
+  playground --help      Show this help
+EOF
 }
 
 exists_matching_file() {
   dir="$1"
   shift
-  find "$dir" -maxdepth 3 -type f \( "$@" \) -print -quit 2>/dev/null | grep -q .
+  find "$dir" -maxdepth 3 -type f \( "$@" \) -print -quit 2>/dev/null | IFS= read -r _
 }
 
 render_preview() {
@@ -102,9 +107,10 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open, Esc=cancel]' \
+        --header='[Enter=open in shell, O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
+        --bind='O:execute-silent(open -- {2})+refresh-preview' \
         --preview "$0 --preview {2}" \
         --preview-window='right:55%:wrap' |
       cut -f2
@@ -119,15 +125,20 @@ pick_project_path() {
 
 if [ "${1-}" = "--preview" ]; then
   if [ $# -ne 2 ]; then
-    usage
+    usage >&2
     exit 2
   fi
   render_preview "$2"
   exit 0
 fi
 
-if [ $# -gt 1 ]; then
+if [ "${1-}" = "--help" ] || [ "${1-}" = "-h" ]; then
   usage
+  exit 0
+fi
+
+if [ $# -gt 1 ]; then
+  usage >&2
   exit 2
 fi
 

--- a/scripts/playground
+++ b/scripts/playground
@@ -34,27 +34,28 @@ render_preview() {
     badges_line="${badges_line} [${candidate}]"
   }
 
-  [ -f "$dir/Gemfile" ] && add_badge "ruby"
-  [ -f "$dir/package.json" ] && add_badge "node"
-  [ -f "$dir/pyproject.toml" ] && add_badge "python"
-  [ -f "$dir/requirements.txt" ] && add_badge "python"
-  [ -f "$dir/Cargo.toml" ] && add_badge "rust"
-  [ -f "$dir/go.mod" ] && add_badge "go"
-  [ -f "$dir/Dockerfile" ] && add_badge "docker"
-  [ -f "$dir/docker-compose.yml" ] && add_badge "docker"
-  [ -f "$dir/compose.yml" ] && add_badge "docker"
-  [ -d "$dir/.git" ] && add_badge "git"
-  [ -f "$dir/.git" ] && add_badge "git"
+  while IFS= read -r path; do
+    base_name="${path##*/}"
 
-  if command -v rg >/dev/null 2>&1; then
-    while IFS= read -r path; do
-      case "$path" in
-        *.md) add_badge "markdown" ;;
-        *.png|*.jpg|*.jpeg|*.gif|*.webp|*.svg) add_badge "images" ;;
-        *.mp3|*.m4a|*.wav|*.flac|*.opus) add_badge "audio" ;;
-        *.mp4|*.mov|*.mkv|*.webm|*.avi) add_badge "video" ;;
-      esac
-    done < <(rg --files --hidden --glob '!**/.git/**' "$dir" 2>/dev/null)
+    case "$path" in
+      "$dir/Gemfile"|Gemfile) add_badge "ruby" ;;
+      "$dir/package.json"|package.json) add_badge "node" ;;
+      "$dir/pyproject.toml"|"$dir/requirements.txt"|pyproject.toml|requirements.txt) add_badge "python" ;;
+      "$dir/Cargo.toml"|Cargo.toml) add_badge "rust" ;;
+      "$dir/go.mod"|go.mod) add_badge "go" ;;
+      "$dir/Dockerfile"|"$dir/docker-compose.yml"|"$dir/compose.yml"|Dockerfile|docker-compose.yml|compose.yml) add_badge "docker" ;;
+    esac
+
+    case "$base_name" in
+      *.md) add_badge "markdown" ;;
+      *.png|*.jpg|*.jpeg|*.gif|*.webp|*.svg) add_badge "images" ;;
+      *.mp3|*.m4a|*.wav|*.flac|*.opus) add_badge "audio" ;;
+      *.mp4|*.mov|*.mkv|*.webm|*.avi) add_badge "video" ;;
+    esac
+  done < <(rg --files --hidden --glob '!**/.git/**' "$dir" 2>/dev/null)
+
+  if rg --files --hidden --glob '**/.git' --glob '**/.git/HEAD' "$dir" 2>/dev/null | IFS= read -r _; then
+    add_badge "git"
   fi
 
   if [ -z "$badges_line" ]; then

--- a/scripts/playground
+++ b/scripts/playground
@@ -22,6 +22,16 @@ Usage:
 EOF
 }
 
+validate_project_name() {
+  name="$1"
+  case "$name" in
+    ""|.|..|*/*|*..*)
+      echo "pg: invalid project name '$name'" >&2
+      return 1
+      ;;
+  esac
+}
+
 render_preview() {
   dir="$1"
   badges_line=""
@@ -54,7 +64,7 @@ render_preview() {
     esac
   done < <(rg --files --hidden --glob '!**/.git/**' "$dir" 2>/dev/null)
 
-  if rg --files --hidden --glob '**/.git' --glob '**/.git/HEAD' "$dir" 2>/dev/null | IFS= read -r _; then
+  if [ -e "$dir/.git" ]; then
     add_badge "git"
   fi
 
@@ -100,8 +110,8 @@ pick_project_path() {
         --header='[Enter=open in shell, Ctrl-O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='ctrl-o:execute-silent(open -- {2})+refresh-preview' \
-        --preview "$0 --preview {2}" \
+        --bind='ctrl-o:execute-silent(open -- {2:q})+refresh-preview' \
+        --preview "$0 --preview {2:q}" \
         --preview-window='right:55%:wrap' |
       cut -f2
   )" || return 1
@@ -137,6 +147,7 @@ if [ "${1-}" = "" ]; then
   exit $?
 fi
 
+validate_project_name "$1" || exit 2
 target="${month_dir}/${1}"
 mkdir -p "$target"
 printf '%s\n' "$target"

--- a/scripts/playground
+++ b/scripts/playground
@@ -107,10 +107,10 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open in shell, O=open in Finder, Esc=cancel]' \
+        --header='[Enter=open in shell, Ctrl-O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='O:execute-silent(open -- {2})+refresh-preview' \
+        --bind='ctrl-o:execute-silent(open -- {2})+refresh-preview' \
         --preview "$0 --preview {2}" \
         --preview-window='right:55%:wrap' |
       cut -f2

--- a/scripts/playground
+++ b/scripts/playground
@@ -22,6 +22,16 @@ Usage:
 EOF
 }
 
+validate_project_name() {
+  name="$1"
+  case "$name" in
+    ""|.|..|*/*|*..*)
+      echo "pg: invalid project name '$name'" >&2
+      return 1
+      ;;
+  esac
+}
+
 render_preview() {
   dir="$1"
   badges_line=""
@@ -54,7 +64,7 @@ render_preview() {
     esac
   done < <(rg --files --hidden --glob '!**/.git/**' "$dir" 2>/dev/null)
 
-  if rg --files --hidden --glob '**/.git' --glob '**/.git/HEAD' "$dir" 2>/dev/null | IFS= read -r _; then
+  if [ -e "$dir/.git" ]; then
     add_badge "git"
   fi
 
@@ -97,11 +107,11 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open in shell, Ctrl-O=open in Finder, Esc=cancel]' \
+        --header='[Enter=open in shell, O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='ctrl-o:execute-silent(open -- {2})+refresh-preview' \
-        --preview "$0 --preview {2}" \
+        --bind='o:execute-silent(open -- {2:q})+refresh-preview,O:execute-silent(open -- {2:q})+refresh-preview' \
+        --preview "$0 --preview {2:q}" \
         --preview-window='right:55%:wrap' |
       cut -f2
   )" || return 1
@@ -137,6 +147,7 @@ if [ "${1-}" = "" ]; then
   exit $?
 fi
 
+validate_project_name "$1" || exit 2
 target="${month_dir}/${1}"
 mkdir -p "$target"
 printf '%s\n' "$target"

--- a/scripts/playground
+++ b/scripts/playground
@@ -22,16 +22,6 @@ Usage:
 EOF
 }
 
-validate_project_name() {
-  name="$1"
-  case "$name" in
-    ""|.|..|*/*|*..*)
-      echo "pg: invalid project name '$name'" >&2
-      return 1
-      ;;
-  esac
-}
-
 render_preview() {
   dir="$1"
   badges_line=""
@@ -64,7 +54,7 @@ render_preview() {
     esac
   done < <(rg --files --hidden --glob '!**/.git/**' "$dir" 2>/dev/null)
 
-  if [ -e "$dir/.git" ]; then
+  if rg --files --hidden --glob '**/.git' --glob '**/.git/HEAD' "$dir" 2>/dev/null | IFS= read -r _; then
     add_badge "git"
   fi
 
@@ -107,11 +97,11 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open in shell, O=open in Finder, Esc=cancel]' \
+        --header='[Enter=open in shell, Ctrl-O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='o:execute-silent(open -- {2:q})+refresh-preview,O:execute-silent(open -- {2:q})+refresh-preview' \
-        --preview "$0 --preview {2:q}" \
+        --bind='ctrl-o:execute-silent(open -- {2})+refresh-preview' \
+        --preview "$0 --preview {2}" \
         --preview-window='right:55%:wrap' |
       cut -f2
   )" || return 1
@@ -147,7 +137,6 @@ if [ "${1-}" = "" ]; then
   exit $?
 fi
 
-validate_project_name "$1" || exit 2
 target="${month_dir}/${1}"
 mkdir -p "$target"
 printf '%s\n' "$target"

--- a/scripts/playground
+++ b/scripts/playground
@@ -107,10 +107,10 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open in shell, Ctrl-O=open in Finder, Esc=cancel]' \
+        --header='[Enter=open in shell, Alt-O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='ctrl-o:execute-silent(open -- {2:q})+refresh-preview' \
+        --bind='alt-o:execute-silent(open -- {2:q})+refresh-preview' \
         --preview "$0 --preview {2:q}" \
         --preview-window='right:55%:wrap' |
       cut -f2

--- a/scripts/playground
+++ b/scripts/playground
@@ -107,10 +107,10 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open in shell, O=open in Finder, Esc=cancel]' \
+        --header='[Enter=open in shell, Ctrl-O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='o:execute-silent(open -- {2:q})+refresh-preview,O:execute-silent(open -- {2:q})+refresh-preview' \
+        --bind='ctrl-o:execute-silent(open -- {2:q})+refresh-preview' \
         --preview "$0 --preview {2:q}" \
         --preview-window='right:55%:wrap' |
       cut -f2

--- a/scripts/playground
+++ b/scripts/playground
@@ -22,12 +22,6 @@ Usage:
 EOF
 }
 
-exists_matching_file() {
-  dir="$1"
-  shift
-  find "$dir" -maxdepth 3 -type f \( "$@" \) -print -quit 2>/dev/null | IFS= read -r _
-}
-
 render_preview() {
   dir="$1"
   badges_line=""
@@ -52,20 +46,15 @@ render_preview() {
   [ -d "$dir/.git" ] && add_badge "git"
   [ -f "$dir/.git" ] && add_badge "git"
 
-  if exists_matching_file "$dir" -iname '*.md'; then
-    add_badge "markdown"
-  fi
-
-  if exists_matching_file "$dir" -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' -o -iname '*.svg'; then
-    add_badge "images"
-  fi
-
-  if exists_matching_file "$dir" -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.wav' -o -iname '*.flac' -o -iname '*.opus'; then
-    add_badge "audio"
-  fi
-
-  if exists_matching_file "$dir" -iname '*.mp4' -o -iname '*.mov' -o -iname '*.mkv' -o -iname '*.webm' -o -iname '*.avi'; then
-    add_badge "video"
+  if command -v rg >/dev/null 2>&1; then
+    while IFS= read -r path; do
+      case "$path" in
+        *.md) add_badge "markdown" ;;
+        *.png|*.jpg|*.jpeg|*.gif|*.webp|*.svg) add_badge "images" ;;
+        *.mp3|*.m4a|*.wav|*.flac|*.opus) add_badge "audio" ;;
+        *.mp4|*.mov|*.mkv|*.webm|*.avi) add_badge "video" ;;
+      esac
+    done < <(rg --files --hidden --glob '!**/.git/**' "$dir" 2>/dev/null)
   fi
 
   if [ -z "$badges_line" ]; then

--- a/scripts/playground
+++ b/scripts/playground
@@ -107,10 +107,10 @@ pick_project_path() {
       fzf --reverse \
         --height=70% \
         --prompt='playground > ' \
-        --header='[Enter=open in shell, Alt-O=open in Finder, Esc=cancel]' \
+        --header='[Enter=open in shell, O=open in Finder, Esc=cancel]' \
         --delimiter=$'\t' \
         --with-nth=1 \
-        --bind='alt-o:execute-silent(open -- {2:q})+refresh-preview' \
+        --bind='o:execute-silent(open -- {2:q})+refresh-preview,O:execute-silent(open -- {2:q})+refresh-preview' \
         --preview "$0 --preview {2:q}" \
         --preview-window='right:55%:wrap' |
       cut -f2

--- a/scripts/playground-path
+++ b/scripts/playground-path
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# playground-path
+#
+# Prints the playground target directory for the current UTC month.
+# If a project name is provided, appends it as a subdirectory.
+
+set -euo pipefail
+
+root="${HOME}/playground"
+month="$(date -u +'%Y-%m')"
+target="${root}/${month}"
+
+if [ "${1-}" != "" ]; then
+  target="${target}/${1}"
+fi
+
+mkdir -p "$target"
+printf '%s\n' "$target"

--- a/scripts/playground-path
+++ b/scripts/playground-path
@@ -2,18 +2,140 @@
 #
 # playground-path
 #
-# Prints the playground target directory for the current UTC month.
-# If a project name is provided, appends it as a subdirectory.
+# Prints a target directory for shell wrappers to `cd` into.
+# - playground-path <name>      => current UTC month project path
+# - playground-path             => interactive fzf picker (latest first)
+# - playground-path --preview <absolute_project_path>
 
 set -euo pipefail
 
-root="${HOME}/playground"
+root="${HOME}/versioned/playground"
 month="$(date -u +'%Y-%m')"
-target="${root}/${month}"
+month_dir="${root}/${month}"
 
-if [ "${1-}" != "" ]; then
-  target="${target}/${1}"
+usage() {
+  echo "usage: playground-path [project_name]" >&2
+}
+
+exists_matching_file() {
+  dir="$1"
+  shift
+  find "$dir" -maxdepth 3 -type f \( "$@" \) -print -quit 2>/dev/null | grep -q .
+}
+
+render_preview() {
+  dir="$1"
+  badges_line=""
+
+  add_badge() {
+    candidate="$1"
+    case " $badges_line " in
+      *"[$candidate]"*) return 0 ;;
+    esac
+    badges_line="${badges_line} [${candidate}]"
+  }
+
+  [ -f "$dir/Gemfile" ] && add_badge "ruby"
+  [ -f "$dir/package.json" ] && add_badge "node"
+  [ -f "$dir/pyproject.toml" ] && add_badge "python"
+  [ -f "$dir/requirements.txt" ] && add_badge "python"
+  [ -f "$dir/Cargo.toml" ] && add_badge "rust"
+  [ -f "$dir/go.mod" ] && add_badge "go"
+  [ -f "$dir/Dockerfile" ] && add_badge "docker"
+  [ -f "$dir/docker-compose.yml" ] && add_badge "docker"
+  [ -f "$dir/compose.yml" ] && add_badge "docker"
+  [ -d "$dir/.git" ] && add_badge "git"
+  [ -f "$dir/.git" ] && add_badge "git"
+
+  if exists_matching_file "$dir" -iname '*.md'; then
+    add_badge "markdown"
+  fi
+
+  if exists_matching_file "$dir" -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' -o -iname '*.svg'; then
+    add_badge "images"
+  fi
+
+  if exists_matching_file "$dir" -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.wav' -o -iname '*.flac' -o -iname '*.opus'; then
+    add_badge "audio"
+  fi
+
+  if exists_matching_file "$dir" -iname '*.mp4' -o -iname '*.mov' -o -iname '*.mkv' -o -iname '*.webm' -o -iname '*.avi'; then
+    add_badge "video"
+  fi
+
+  if [ -z "$badges_line" ]; then
+    echo "tags: [unknown]"
+    return 0
+  fi
+
+  printf 'tags:%s\n' "$badges_line"
+}
+
+list_projects() {
+  if [ ! -d "$root" ]; then
+    return 0
+  fi
+
+  find "$root" -mindepth 2 -maxdepth 2 -type d -print0 | while IFS= read -r -d '' dir; do
+    mtime="$(stat -f '%m' "$dir" 2>/dev/null || stat -c '%Y' "$dir" 2>/dev/null || echo 0)"
+    rel="${dir#"$root"/}"
+    printf '%s\t%s\t%s\n' "$mtime" "$rel" "$dir"
+  done | sort -t$'\t' -k1,1nr | cut -f2-3
+}
+
+pick_project_path() {
+  if ! command -v fzf >/dev/null 2>&1; then
+    echo "pg: fzf is required for interactive mode" >&2
+    return 127
+  fi
+
+  projects="$(list_projects)"
+
+  if [ -z "$projects" ]; then
+    mkdir -p "$month_dir"
+    printf '%s\n' "$month_dir"
+    return 0
+  fi
+
+  selection="$(
+    printf '%s\n' "$projects" |
+      fzf --reverse \
+        --height=70% \
+        --prompt='playground > ' \
+        --header='[Enter=open, Esc=cancel]' \
+        --delimiter=$'\t' \
+        --with-nth=1 \
+        --preview "$0 --preview {2}" \
+        --preview-window='right:55%:wrap' |
+      cut -f2
+  )" || return 1
+
+  if [ -z "$selection" ]; then
+    return 1
+  fi
+
+  printf '%s\n' "$selection"
+}
+
+if [ "${1-}" = "--preview" ]; then
+  if [ $# -ne 2 ]; then
+    usage
+    exit 2
+  fi
+  render_preview "$2"
+  exit 0
 fi
 
+if [ $# -gt 1 ]; then
+  usage
+  exit 2
+fi
+
+if [ "${1-}" = "" ]; then
+  pick_project_path
+  exit $?
+fi
+
+target="${month_dir}/${1}"
 mkdir -p "$target"
 printf '%s\n' "$target"

--- a/zshrc
+++ b/zshrc
@@ -219,7 +219,7 @@ alias .....="cd ../../../.."
 #endregion
 
 #region# magic folder commands
-alias pg="playground"
+# pg is a shell function from ~/.profile so it can change the current shell directory.
 #endregion
 
 #region# better cat and "imagec" (icat)

--- a/zshrc
+++ b/zshrc
@@ -219,15 +219,7 @@ alias .....="cd ../../../.."
 #endregion
 
 #region# magic folder commands
-pg() {
-  local target
-  target="$(playground "$@")" || return $?
-
-  cd "$target" || {
-    echo "pg: unable to change directory to $target" >&2
-    return 1
-  }
-}
+alias pg="playground"
 #endregion
 
 #region# better cat and "imagec" (icat)

--- a/zshrc
+++ b/zshrc
@@ -218,6 +218,10 @@ alias ....="cd ../../.."
 alias .....="cd ../../../.."
 #endregion
 
+#region# magic folder commands
+alias pg="playground"
+#endregion
+
 #region# better cat and "imagec" (icat)
 if command_exists bat; then
   # use bat for cat, and let it behave like cat
@@ -292,18 +296,6 @@ alias h="history 0 | fzf"
 bindkey "^[^[[C" forward-word
 bindkey "^[^[[D" backward-word
 #endregion
-
-#region Setup PKM tools
-export PKM_NOTES_ROOT="$HOME/versioned/gildesmarais/wiki"
-export PKM_TODO_AUTO_GIT_SYNC=true
-
-alias note="cd $PKM_NOTES_ROOT && pkm day && popd"
-alias wiki="pkm search --interactive"
-#endregion
-
-export VISUAL=code
-
-[[ $- == *i* ]] && pkm todo motd
 
 #region Completions
 autoload -U compinit && compinit

--- a/zshrc
+++ b/zshrc
@@ -219,7 +219,15 @@ alias .....="cd ../../../.."
 #endregion
 
 #region# magic folder commands
-alias pg="playground"
+pg() {
+  local target
+  target="$(playground "$@")" || return $?
+
+  cd "$target" || {
+    echo "pg: unable to change directory to $target" >&2
+    return 1
+  }
+}
 #endregion
 
 #region# better cat and "imagec" (icat)

--- a/zshrc
+++ b/zshrc
@@ -218,10 +218,6 @@ alias ....="cd ../../.."
 alias .....="cd ../../../.."
 #endregion
 
-#region# magic folder commands
-# pg is a shell function from ~/.profile so it can change the current shell directory.
-#endregion
-
 #region# better cat and "imagec" (icat)
 if command_exists bat; then
   # use bat for cat, and let it behave like cat


### PR DESCRIPTION
## Summary
This PR completes the `pg`/`playground` workflow refresh in dotfiles.

- Promotes playground navigation into a dedicated script: `scripts/playground`
- Adds interactive `fzf` project selection for plain `pg` / `playground`
- Supports named targets (`pg <name>`) under the current UTC month folder
- Adds Finder open shortcut from picker (`Ctrl-O`)
- Switches preview badge detection to an `rg`-first approach to reduce repeated scans
- Restores shell behavior so `pg` changes directory (instead of only printing paths)

## Key behavior
- `pg <name>` => creates/selects `~/versioned/playground/YYYY-MM/<name>` and `cd`s into it
- `pg` => opens `fzf` picker and `cd`s to selected project
- Picker preview tags include stack/media/git signals
- `playground --help` provides usage

## Notable implementation changes
- `scripts/playground-path` renamed to `scripts/playground` (hard rename)
- `zshrc` now defines `pg()` wrapper that calls `playground` and `cd`s into returned path
- README quick-start table includes `./scripts/playground`
- Preview detection now uses a single `rg --files` pass for stack/media tags plus git probe

## Validation
- `shellcheck scripts/playground` passes
- Manual smoke checks covered:
  - named mode (`pg foobar`) `cd` behavior
  - picker mode selection `cd` behavior
  - Finder shortcut wiring (`Ctrl-O`)
  - preview tag semantics (stack/media/git/unknown)
  - help output
